### PR TITLE
Added missing conditional line to skip building docker images if PR is created from a fork

### DIFF
--- a/template/.github/workflows/publish_main_artifacts.yml.j2
+++ b/template/.github/workflows/publish_main_artifacts.yml.j2
@@ -39,6 +39,7 @@ jobs:
       - name: Build Docker image
         env:
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+        if: env.NEXUS_PASSWORD != null
         run: make docker
 
       - name: Compile chart

--- a/template/.github/workflows/publish_pr_artifacts.yml.j2
+++ b/template/.github/workflows/publish_pr_artifacts.yml.j2
@@ -41,6 +41,7 @@ jobs:
       - name: Build Docker image
         env:
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+        if: env.NEXUS_PASSWORD != null
         run: make docker
 
       - name: Compile chart

--- a/template/.github/workflows/publish_release_artifacts.yml.j2
+++ b/template/.github/workflows/publish_release_artifacts.yml.j2
@@ -35,6 +35,7 @@ jobs:
       - name: Build Docker image
         env:
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+        if: env.NEXUS_PASSWORD != null
         run: make docker
 
       - name: Compile chart
@@ -46,6 +47,7 @@ jobs:
       - name: Publish Chart
         env:
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+        if: env.NEXUS_PASSWORD != null
         run: >-
           /usr/bin/curl
           --fail


### PR DESCRIPTION
The github actions files are missing the if statement to skip actions when PRs are created from a fork in a couple of places.
This causes CI runs to fail for example for [dependabot pull requests](https://github.com/stackabletech/superset-operator/runs/4432984859?check_suite_focus=true)