### PR TITLE
Skip update manifest gh actions for pull requests that originate from forks

### DIFF
--- a/template/.github/workflows/pr_generate_manifests.yml.j2
+++ b/template/.github/workflows/pr_generate_manifests.yml.j2
@@ -20,8 +20,14 @@ jobs:
         with:
           version: v3.6.2
       - name: update manifests
+        env:
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+        if: env.NEXUS_PASSWORD != null
         run: make generate-manifests
       - name: Add & Commit
+        env:
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+        if: env.NEXUS_PASSWORD != null
         uses: EndBug/add-and-commit@v7
         with:
           default_author: user_info

--- a/template/.github/workflows/rust.yml
+++ b/template/.github/workflows/rust.yml
@@ -8,6 +8,8 @@ on:
   push:
     branches:
       - main
+      - staging
+      - trying
   pull_request:
 
 env:
@@ -32,9 +34,6 @@ jobs:
       - uses: actions-rs/cargo@v1.0.3
         with:
           command: test
-      - uses: actions-rs/cargo@v1.0.3
-        with:
-          command: clean
 
   rustfmt:
     name: Run rustfmt
@@ -80,6 +79,7 @@ jobs:
             toolchain: stable
             components: clippy
             override: true
+      - uses: Swatinem/rust-cache@v1.3.0
       # We need this due to: https://github.com/actions-rs/clippy-check/issues/2
       - name: Check workflow permissions
         id: check_permissions

--- a/template/bors.toml
+++ b/template/bors.toml
@@ -1,0 +1,10 @@
+status = [
+    'Run tests',
+    'Run rustfmt',
+    'Run rustdoc',
+    'Run clippy',
+    'Run cargo deny (bans licenses sources)'
+]
+delete_merged_branches = true
+pr_status = [ 'license/cla' ]
+timeout_sec = 7200


### PR DESCRIPTION
These do not have access to the necessary secrets and will fail anyway.