### PR TITLE
Revert #130, downgrade cargo-deny-action to 1.2.6

### DIFF
--- a/template/.github/workflows/rust.yml
+++ b/template/.github/workflows/rust.yml
@@ -112,6 +112,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.4.0
-      - uses: EmbarkStudios/cargo-deny-action@v1.2.9
+      - uses: EmbarkStudios/cargo-deny-action@v1.2.6
         with:
           command: check ${{ matrix.checks }}


### PR DESCRIPTION
This reverts commit 4162060d4df9108ed5830da0ef6aba2256884491.

Cargo-deny 0.11.0 no longer applies exceptions to workspace-local crates, causing CI failures everywhere.