### PR TITLE
Added an environment variable to disable lookups in log4j strings.

### DIFF
--- a/template/docker/Dockerfile.j2
+++ b/template/docker/Dockerfile.j2
@@ -22,4 +22,7 @@ RUN groupadd -g 1000 stackable && adduser -u 1000 -g stackable -c 'Stackable Ope
 
 USER 1000:1000
 
+# Mitigate CVE-2021-44228 (Log4Shell)
+ENV LOG4J_FORMAT_MSG_NO_LOOKUPS=true
+
 ENTRYPOINT ["/stackable-{[ operator.product_string }]-operator"]


### PR DESCRIPTION
This is in order to protect against Log4Shell (CVE-2021-44228).