### PR TITLE
Use Ansible command module rather than shell to fix commits with quotes (')

### DIFF
--- a/playbook/playbook.yaml
+++ b/playbook/playbook.yaml
@@ -14,13 +14,17 @@
         state: directory
 
     - name: Configure git author mail
-      shell: git config --global user.email "{{ author_mail }}"
+      command:
+        argv: [git, config, --global, user.email, "{{ author_mail }}"]
 
     - name: Configure git author name
-      shell: git config --global user.name "{{ author_name }}"
+      command:
+        argv: [git, config, --global, user.name, "{{ author_name }}"]
 
     - name: Login to github
-      shell: echo "{{ gh_access_token }}" | gh auth login --with-token
+      command:
+        argv: [gh, auth, login, --with-token]
+        stdin: "{{ gh_access_token }}"
       register: loginresult
       ignore_errors: yes
 

--- a/playbook/update_repo.yaml
+++ b/playbook/update_repo.yaml
@@ -6,8 +6,8 @@
     update: no
 
 - name: Create new branch
-  shell: git checkout -b {{ pr_branch_name }}
-  args:
+  command:
+    argv: [git, checkout, -b, "{{ pr_branch_name }}"]
     chdir: "{{ work_dir }}/{{ operator.name }}"
 
 # Check if anything was changed, if yes commit changes and create a pull request, otherwise skip rest of this play
@@ -75,23 +75,23 @@
 - name: Create PR if changes were performed
   block:
     - name: Stage all changes
-      shell: git add .
-      args:
+      command:
+        argv: [git, add, .]
         chdir: "{{ work_dir }}/{{ operator.name }}"
 
     - name: Commit changes
-      shell: git commit -a -m '{{ commit_message }}'
-      args:
+      command:
+        argv: [git, commit, -a, -m, "{{ commit_message }}"]
         chdir: "{{ work_dir }}/{{ operator.name }}"
 
     - name: Push changes
-      shell: git push --set-upstream origin {{ pr_branch_name }}
-      args:
+      command:
+        argv: [git, push, --set-upstream, origin, "{{ pr_branch_name }}"]
         chdir: "{{ work_dir }}/{{ operator.name }}"
 
     - name: Create PR
-      shell: gh pr create --base main --title "{{ pr_title }}" --body "{{ pr_body }} --reviewer "@stackabletech/developers""
-      args:
+      command:
+        argv: [gh, pr, create, --base, main, --title, "{{ pr_title }}", --body, "{{ pr_body }}", --reviewer, "@stackabletech/developers"]
         chdir: "{{ work_dir }}/{{ operator.name }}"
 
   when: directory_result.changed or template_result.changed or file_result.changed or deletion_result.changed


### PR DESCRIPTION
Followup to #35. By setting `argv` to an explicit array with avoid running via a shell, and thus avoid the argument quotation problem.