### PR TITLE
Disable Rust 2021 compat warnings

### DIFF
--- a/template/.github/workflows/rust.yml
+++ b/template/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: '0'
   CARGO_PROFILE_DEV_DEBUG: '0'
-  RUSTFLAGS: "-D warnings -W rust-2021-compatibility"
+  RUSTFLAGS: "-D warnings"
 
 jobs:
 


### PR DESCRIPTION
These should be handled when doing the upgrade, and still cause false positives
in Post-2021 crates (such as zookeeper-operator).