### PR TITLE
Changed bors commit message and added a reference in the PR template

### DIFF
--- a/template/.github/pull_request_template.md
+++ b/template/.github/pull_request_template.md
@@ -1,8 +1,14 @@
 ## Description
 
+*Please add a description here. This will become the commit message of the merge request later.*
+
+<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->
+
 ## Review Checklist
 - [ ] Code contains useful comments
 - [ ] (Integration-)Test cases added (or not applicable)
 - [ ] Documentation added (or not applicable)
 - [ ] Changelog updated (or not applicable)
 - [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
+
+Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)

--- a/template/bors.toml
+++ b/template/bors.toml
@@ -8,3 +8,4 @@ status = [
 delete_merged_branches = true
 pr_status = [ 'license/cla' ]
 timeout_sec = 7200
+cut_body_after = "<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->"

--- a/template/bors.toml
+++ b/template/bors.toml
@@ -6,6 +6,7 @@ status = [
     'Run cargo deny (bans licenses sources)'
 ]
 delete_merged_branches = true
+use_squash_merge = true
 pr_status = [ 'license/cla' ]
 timeout_sec = 7200
 cut_body_after = "<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->"

--- a/template/bors.toml
+++ b/template/bors.toml
@@ -6,7 +6,6 @@ status = [
     'Run cargo deny (bans licenses sources)'
 ]
 delete_merged_branches = true
-use_squash_merge = true
 pr_status = [ 'license/cla' ]
 timeout_sec = 7200
 cut_body_after = "<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->"

--- a/template/deploy/helm/[[product]]-operator/templates/roles.yaml.j2
+++ b/template/deploy/helm/[[product]]-operator/templates/roles.yaml.j2
@@ -86,7 +86,11 @@ rules:
   - apiGroups:
       - apps
     resources:
+{[% if operator.product_string in ['opa'] %}]
+      - daemonsets
+{[% else %}]
       - statefulsets
+{[% endif %}]
     verbs:
       - create
       - delete


### PR DESCRIPTION
The description of the PR becomes the commit message of the merge commit after it is merged (see [here](https://github.com/stackabletech/druid-operator/commit/d74e1cdc1337bf57efe9aed4568dbb1fad2bdd6d) for an example).

This PR uses the `cut_body_after` property to cut off our review checklist. It also adds a short note to use bors for the merge.

~It also configures bors to do a squash merge.~ (Doesn't work)