### PR TITLE
Apply cache keys to each Rust job

### DIFF
--- a/template/.github/workflows/rust.yml
+++ b/template/.github/workflows/rust.yml
@@ -31,6 +31,8 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v1.3.0
+        with:
+          key: test
       - uses: actions-rs/cargo@v1.0.3
         with:
           command: test
@@ -63,6 +65,8 @@ jobs:
           components: rustfmt
           override: true
       - uses: Swatinem/rust-cache@v1.3.0
+        with:
+          key: doc
       - uses: actions-rs/cargo@v1.0.3
         with:
           command: doc
@@ -80,6 +84,8 @@ jobs:
             components: clippy
             override: true
       - uses: Swatinem/rust-cache@v1.3.0
+        with:
+          key: clippy
       # We need this due to: https://github.com/actions-rs/clippy-check/issues/2
       - name: Check workflow permissions
         id: check_permissions


### PR DESCRIPTION
Tested in https://github.com/stackabletech/zookeeper-operator/tree/bugfix/ci-cache, compare https://github.com/stackabletech/zookeeper-operator/actions/runs/1667329561 to https://github.com/stackabletech/zookeeper-operator/actions/runs/1667310952.