### PR TITLE
Give operators permission to manage RBAC objects

### DIFF
--- a/template/deploy/helm/[[product]]-operator/templates/roles.yaml.j2
+++ b/template/deploy/helm/[[product]]-operator/templates/roles.yaml.j2
@@ -75,6 +75,19 @@ rules:
       - configmaps
       - services
       - endpoints
+      - serviceaccounts
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebinding
     verbs:
       - create
       - delete


### PR DESCRIPTION
Required by https://github.com/stackabletech/kafka-operator/pull/275