### PR TITLE
Add reference to Kafka broker clusterrole

### DIFF
--- a/template/deploy/helm/[[product]]-operator/templates/deployment.yaml
+++ b/template/deploy/helm/[[product]]-operator/templates/deployment.yaml
@@ -43,6 +43,11 @@ spec:
           volumeMounts:
             - mountPath: /etc/stackable/{{ include "operator.appname" . }}/config-spec
               name: config-spec
+{[% if operator.product_string in ['kafka'] %}]
+          env:
+            - name: KAFKA_BROKER_CLUSTERROLE
+              value: {{ .Release.Name }}-kafka-broker-clusterrole
+{[% endif %}]
       volumes:
         - name: config-spec
           configMap:


### PR DESCRIPTION
Required by https://github.com/stackabletech/kafka-operator/pull/275

Feels like this is the completely wrong place for this kind of thing, ideally we'd have some way for the repository to declare this kind of thing locally.. :/