### PR TITLE
Updated PR Template to include a check of the helm chart

### DIFF
--- a/template/.github/pull_request_template.md
+++ b/template/.github/pull_request_template.md
@@ -10,5 +10,6 @@
 - [ ] Documentation added (or not applicable)
 - [ ] Changelog updated (or not applicable)
 - [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
+- [ ] Helm chart can be installed and deployed operator works (or not applicable)
 
 Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)

--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -34,21 +34,16 @@ compile-chart: version crds config
 chart-clean:
 	rm -rf deploy/helm/{[ operator.product_string }]-operator/configs
 	rm -rf deploy/helm/{[ operator.product_string }]-operator/crds
-	rm -rf deploy/helm/{[ operator.product_string }]-operator/templates/crds.yaml
 
 version:
 	yq eval -i '.version = ${VERSION} | .appVersion = ${VERSION}' deploy/helm/{[ operator.product_string }]-operator/Chart.yaml
 
-config: deploy/helm/{[ operator.product_string }]-operator/configs
-
-deploy/helm/{[ operator.product_string }]-operator/configs:
+config:
 	cp -r deploy/config-spec deploy/helm/{[ operator.product_string }]-operator/configs
 
-crds: deploy/helm/{[ operator.product_string }]-operator/crds/crds.yaml
-
-deploy/helm/{[ operator.product_string }]-operator/crds/crds.yaml:
+crds:
 	mkdir -p deploy/helm/{[ operator.product_string }]-operator/crds
-	cat deploy/crd/*.yaml | yq eval '.metadata.annotations["helm.sh/resource-policy"]="keep"' - > ${@}
+	cat deploy/crd/*.yaml | yq eval '.metadata.annotations["helm.sh/resource-policy"]="keep"' - > deploy/helm/{[ operator.product_string }]-operator/crds/crds.yaml
 
 chart-lint: compile-chart
 	docker run -it -v $(shell pwd):/build/helm-charts -w /build/helm-charts quay.io/helmpack/chart-testing:v3.5.0  ct lint --config deploy/helm/ct.yaml


### PR DESCRIPTION
I kept forgetting this, but it is important. The operator deployed as a helm chart should work. At the moment this is also the easiest (only?) way to check if the RBAC rules work properly.

Also `make compile-chart` now always rebuilds the charts.