### PR TITLE
Make copying of config-spec conditional

### DIFF
--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -40,7 +40,7 @@ version:
 
 config:
 	if [ -d "deploy/config-spec/" ]; then\
-		mkdir -p deploy/helm/zookeeper-operator/configs;\
+		mkdir -p deploy/helm/{[ operator.product_string }]-operator/configs;\
 		cp -r deploy/config-spec/* deploy/helm/{[ operator.product_string }]-operator/configs;\
 	fi
 

--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -39,8 +39,10 @@ version:
 	yq eval -i '.version = ${VERSION} | .appVersion = ${VERSION}' deploy/helm/{[ operator.product_string }]-operator/Chart.yaml
 
 config:
-	mkdir -p deploy/helm/zookeeper-operator/configs
-	cp -r deploy/config-spec/* deploy/helm/{[ operator.product_string }]-operator/configs
+	if [ -d "deploy/config-spec/" ]; then\
+		mkdir -p deploy/helm/zookeeper-operator/configs;\
+		cp -r deploy/config-spec/* deploy/helm/{[ operator.product_string }]-operator/configs;\
+	fi
 
 crds:
 	mkdir -p deploy/helm/{[ operator.product_string }]-operator/crds


### PR DESCRIPTION
Some operators (looking at you, Regorule) do not have config-spec files, which caused the generate manifest step to fail after PR #61 which changed the syntax for copying these files.

This adds a check if any config-spec files are present and skips copying them if not. This requires that operators do not have .dummy files in place, as was the case for regorule (fixed in https://github.com/stackabletech/regorule-operator/pull/195 )