### PR TITLE
Change bors required checks from publishing to chart testing

### DIFF
--- a/template/bors.toml
+++ b/template/bors.toml
@@ -1,5 +1,5 @@
 status = [
-    'Package Charts, Build Docker Image and publish them'
+    'Run Chart Tests'
 ]
 delete_merged_branches = true
 use_squash_merge = true


### PR DESCRIPTION
Publishing Artifacts step is skipped for bors staging branches but marked as required.

This keeps bors from merging any prs. Since we will move building charts and docker images to earlier stages soon anyway the important steps will all have happened when chart testing is done, so we can make this the required step instead.