### PR TITLE
Remove unused extra crates for the hbase-operator

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -48,9 +48,6 @@ repositories:
     url: stackabletech/hbase-operator.git
     product_string: hbase
     pretty_string: Apache HBase
-    extra_crates:
-      - stackable-hdfs-crd
-      - stackable-zookeeper-crd
   - name: hdfs-operator
     url: stackabletech/hdfs-operator.git
     product_string: hdfs


### PR DESCRIPTION
After the rework of the hbase-operator the extra crates are not used anymore and were removed.

see stackabletech/hbase-operator#43