### PR TITLE
Changes playbook to use 'git diff' to determine if a PR needs to be created

### DIFF
--- a/playbook/update_repo.yaml
+++ b/playbook/update_repo.yaml
@@ -86,6 +86,7 @@
       command:
         argv: [ git, diff, --exit-code ]
         chdir: "{{ work_dir }}/{{ operator.name }}"
+      ignore_errors: true
       register: git_change
 
   tags: local

--- a/playbook/update_repo.yaml
+++ b/playbook/update_repo.yaml
@@ -14,6 +14,10 @@
 # Check if anything was changed, if yes commit changes and create a pull request, otherwise skip rest of this play
 - name: Perform local file operations
   block:
+    - name: Display current operator
+      debug:
+        var: operator.name
+
     - name: Find template files
       find:
         paths: "{{ template_dir }}/"
@@ -77,6 +81,13 @@
       command:
         argv: [ make, compile-chart, generate-manifests ]
         chdir: "{{ work_dir }}/{{ operator.name }}"
+
+    - name: Run 'git diff' to check for changes that would require creating a pr
+      command:
+        argv: [ git, diff, --exit-code ]
+        chdir: "{{ work_dir }}/{{ operator.name }}"
+      register: git_change
+
   tags: local
 
 # Check if anything was changed, if yes commit changes and create a pull request, otherwise skip rest of this play
@@ -102,4 +113,4 @@
         argv: [gh, pr, create, --base, main, --title, "{{ pr_title }}", --body, "{{ pr_body }}", --reviewer, "@stackabletech/developers"]
         chdir: "{{ work_dir }}/{{ operator.name }}"
 
-  when: directory_result.changed or template_result.changed or file_result.changed or deletion_result.changed
+  when: git_change.rc != 0


### PR DESCRIPTION
Currently the playbook relies on ansibles "changed" state for actions, which may not be accurate, as we regenerate manifests after ansible is finished.

Added debug statement so we can tell in the output which operator is currently being processed.