### PR TITLE
Renovate Updates for Github Actions

### DIFF
--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -107,7 +107,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2.4.0
-      - uses: EmbarkStudios/cargo-deny-action@2a55392931cddc0ae1d7397515fd0951d39ebaf2 # renovate: tag=v1.2.10
+      - uses: EmbarkStudios/cargo-deny-action@4340bbf5bc9e7034fae7c4857e9ab87cab35c905 # renovate: tag=v1.2.11
         with:
           command: check ${{ matrix.checks }}
 
@@ -238,7 +238,7 @@ jobs:
         run: git diff --exit-code
       - name: Git Diff showed uncommitted changes
         if: ${{ failure() }}
-        uses: actions/github-script@f05a81df23035049204b043b50c3322045ce7eb3 # renovate: tag=v3
+        uses: actions/github-script@e3cbab99d3a9b271e1b79fc96d103a4a5534998c # renovate: tag=v5
         with:
           script: |
             core.setFailed('Committed charts were not up to date, please regenerate and re-commit!')

--- a/template/.github/workflows/reviewdog.yaml
+++ b/template/.github/workflows/reviewdog.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2.4.0
-      - uses: reviewdog/action-detect-secrets@v0.7.1
+      - uses: reviewdog/action-detect-secrets@80a6e68bd1adeb7b7bbc7c69f2e9813f94d41a28 # renovate: tag=v0.7.1
         with:
           github_token: ${{ secrets.github_token }}
 
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2.4.0
-      - uses: reviewdog/action-hadolint@1e34f93387b47709298a91edb132af6c02a4bae1 # renovate: tag=v1.6.0
+      - uses: reviewdog/action-hadolint@5cf6f59448898674422be225b024fa2442ac3caa # renovate: tag=v1.27.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2.4.0
-      - uses: reviewdog/action-markdownlint@a506383bccd0869312895b715b68a4ecd924e9f7 # renovate: tag=v0.1
+      - uses: reviewdog/action-markdownlint@40f5a7a4afc06d314a2c3a72f42c387b5187deaa # renovate: tag=v0.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This bunches a couple of renovate action updates:

reviewdog/action-hadolint	        	minor	v1.6.0 -> v1.27.0
actions/github-script	                	major	v3 -> v5
reviewdog/action-markdownlint		minor	v0.1 -> v0.3
EmbarkStudios/cargo-deny-action		patch	v1.2.10 -> v1.2.11
actions/github-script	                	major	v3 -> v5
reviewdog/action-detect-secrets		pin	         v0.7.1 -> v0.7.1