### PR TITLE
Fix unneeded PRs and CRD generation error.

### DIFF
--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -63,6 +63,7 @@ clean-crds:
 	rm -rf deploy/crd/*
 
 generate-crds:
+	touch rust/operator-binary/build.rs
 	cargo build
 
 regenerate-charts: clean-crds chart-clean clean-manifests generate-crds compile-chart generate-manifests

--- a/template/renovate.json.j2
+++ b/template/renovate.json.j2
@@ -28,5 +28,5 @@
       "after 5:00 and before 6:00 every weekday"
     ]
   },
-  "ignorePaths": {[ workflow_files.files | map(attribute='path') | map('replace', '.j2', '') | map('replace', base_dir+'/template/', '') | to_json }]
+  "ignorePaths": {[ workflow_files.files | map(attribute='path') | map('replace', '.j2', '') | map('replace', base_dir+'/template/', '') | sort() | to_json }]
 }


### PR DESCRIPTION
Adds a sort step to generatig the list of github action files to be ignored by renovate in the downstream repos.
fixes #74

Adds updating of timestamp on build.rs to makefile when generating crds.
fixes #75