### PR TITLE
Changed trigger on action to generate downstream PRs to run once a day as well as on manual dispatch

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -1,14 +1,14 @@
 ---
-name: Rust
+name: Generate Downstream PRs
 
 on:
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - README.adoc
-      - LICENSE
-      - test.sh
+  workflow_dispatch:
+    inputs:
+      message:
+        description: "Message to include in the generated commits:"
+        required: true
+  schedule:
+    - cron: 5 4 * * * # run at 04:05 every morning
 
 jobs:
   create-prs:
@@ -23,16 +23,29 @@ jobs:
             sudo apt install -y software-properties-common && \
             sudo apt-add-repository ppa:ansible/ansible -y && \
             sudo apt install -y ansible
+
       - name: Install Github CLI
         run: |
             curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg && \
             echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
             sudo apt update && \
             sudo apt install gh
+
+      # Create commit message depending on whether this is run manually or due to a scheduled run
+      - name: Set commit message for manual dispatch
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo "COMMIT_MESSAGE=Manual run triggered by: ${{ github.event.sender.login }} with message [${{ github.event.inputs.message }}]" >> $GITHUB_ENV
+      - name: Set commit message for schedule
+        if: ${{ github.event_name == 'schedule' }}
+        run: |
+          echo "COMMIT_MESSAGE=Daily run triggered" >> $GITHUB_ENV
+
+      # Generate PRs
       - name: Run playbook
         run: |
           # Funnel via JSON to ensure that values are escaped properly
-          echo '{}' | jq '{commit_hash: $ENV.GITHUB_SHA, original_commit_message: $ENV.COMMIT_MESSAGE, base_dir: $pwd,  gh_access_token: $ENV.GH_ACCESS_TOKEN}' --arg pwd "$(pwd)" > vars.json
+          echo '{}' | jq '{commit_hash: $ENV.GITHUB_SHA, reason: $ENV.COMMIT_MESSAGE, base_dir: $pwd,  gh_access_token: $ENV.GH_ACCESS_TOKEN}' --arg pwd "$(pwd)" > vars.json
           ansible-playbook playbook/playbook.yaml --extra-vars "@vars.json"
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}

--- a/playbook/group_vars/all/vars
+++ b/playbook/group_vars/all/vars
@@ -16,8 +16,8 @@ pr_branch_name: template_{{ commit_short_hash }}
 commit_message: |
     Generated commit to update templated files based on rev {{ commit_short_hash }} in stackabletech/operator-templating repo.
 
-    Original commit message:
-    {{ original_commit_message }}
+    Triggered by:
+    {{ reason }}
 
 # Title and body of created PRs
 pr_title: "Update templated files to rev {{ commit_short_hash }}"
@@ -25,5 +25,5 @@ pr_title: "Update templated files to rev {{ commit_short_hash }}"
 pr_body: |
     Automatically created PR based on commit {{ commit_hash }} in stackabletech/operator-templating repo.
 
-    Original commit message:
-    {{ original_commit_message }}
+    Triggered by:
+    {{ reason }}

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-ansible-playbook playbook/playbook.yaml --tags "local" --extra-vars "gh_access_token=unneeded base_dir=$(pwd) commit_hash=12345 original_commit_message='original message'"
+ansible-playbook playbook/playbook.yaml --tags "local" --extra-vars "gh_access_token=unneeded base_dir=$(pwd) commit_hash=12345 reason='original message'"


### PR DESCRIPTION
This should make it easier to commit a batch of changes to the repository and then run templating to generate only one downstream PR.