### PR TITLE
Added .markdownlint for self.

### DIFF
--- a/.github/workflows/reviewdog.yaml
+++ b/.github/workflows/reviewdog.yaml
@@ -52,6 +52,7 @@ jobs:
       - uses: reviewdog/action-markdownlint@40f5a7a4afc06d314a2c3a72f42c387b5187deaa # renovate: tag=v0.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          markdownlint_flags: '**/*.md.j2'
 
   shellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/reviewdog.yaml
+++ b/.github/workflows/reviewdog.yaml
@@ -52,7 +52,7 @@ jobs:
       - uses: reviewdog/action-markdownlint@40f5a7a4afc06d314a2c3a72f42c387b5187deaa # renovate: tag=v0.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          markdownlint_flags: '**/*.md.j2'
+          markdownlint_flags: '**/*(*.md|*.md.j2)'
 
   shellcheck:
     runs-on: ubuntu-latest

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,24 @@
+---
+# All defaults or options can be checked here:
+# https://github.com/DavidAnson/markdownlint/blob/main/schema/.markdownlint.yaml
+
+# Default state for all rules
+default: true
+
+files:
+  - '*.md'
+  - '*.md.j2'
+
+# MD013/line-length - Line length
+MD013:
+  # Number of characters
+  line_length: 9999
+  # Number of characters for headings
+  heading_line_length: 9999
+  # Number of characters for code blocks
+  code_block_line_length: 9999
+
+# MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
+MD024:
+  # Only check sibling headings
+  siblings_only: true

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -8,11 +8,11 @@ default: true
 # MD013/line-length - Line length
 MD013:
   # Number of characters
-  line_length: 10
+  line_length: 9999
   # Number of characters for headings
-  heading_line_length: 10
+  heading_line_length: 9999
   # Number of characters for code blocks
-  code_block_line_length: 10
+  code_block_line_length: 9999
 
 # MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
 MD024:

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -5,10 +5,6 @@
 # Default state for all rules
 default: true
 
-files:
-  - '*.md'
-  - '*.md.j2'
-
 # MD013/line-length - Line length
 MD013:
   # Number of characters

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -12,11 +12,11 @@ files:
 # MD013/line-length - Line length
 MD013:
   # Number of characters
-  line_length: 9999
+  line_length: 10
   # Number of characters for headings
-  heading_line_length: 9999
+  heading_line_length: 10
   # Number of characters for code blocks
-  code_block_line_length: 9999
+  code_block_line_length: 10
 
 # MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
 MD024:


### PR DESCRIPTION
The action it's self was not tested but this works:

`docker run -v $PWD:/workdir ghcr.io/igorshubovych/markdownlint-cli:latest '**/*(*.md|*.md.j2)'`

where the output is:

```
template/deploy/DO_NOT_EDIT.md.j2:1 MD041/first-line-heading/first-line-h1 First line in a file should be a top-level heading [Context: "These Helm charts and manifest..."]
template/deploy/helm/[[product]]-operator/README.md.j2:21:77 MD034/no-bare-urls Bare URL used [Context: "https://docs.stackable.tech/"]
template/deploy/helm/[[product]]-operator/README.md.j2:23:65 MD034/no-bare-urls Bare URL used [Context: "https://github.com/stackablete..."]
template/deploy/helm/[[product]]-operator/README.md.j2:27:1 MD034/no-bare-urls Bare URL used [Context: "https://github.com/stackablete..."]
```
