### PR TITLE
Cleanup after install using microdnf

### DIFF
--- a/template/docker/Dockerfile.j2
+++ b/template/docker/Dockerfile.j2
@@ -11,6 +11,7 @@ LABEL maintainer="Stackable GmbH"
 RUN microdnf update --disablerepo=* --enablerepo=ubi-8-baseos --enablerepo=ubi-8-baseos -y \
   && rm -rf /var/cache/yum \
   && microdnf install --disablerepo=* --enablerepo=ubi-8-baseos shadow-utils -y \
+  && microdnf clean all \
   && rm -rf /var/cache/yum
 
 COPY --from=builder /app/stackable-{[ operator.name }] /


### PR DESCRIPTION
In our Dockerfile(s) we use microdnf but do not use the command `microdnf clean all` at the end as recommended.

With the [release 2.9.1 of hadolint](https://github.com/hadolint/hadolint/releases/tag/v2.9.1), this is added as a check and reported. (after fixing issue https://github.com/hadolint/hadolint/issues/742)

This PR adds the cleanup as recommended.