### PR TITLE
Fix 'make crds' for repositories with multiple binary crates and improve error propagation in Makefile

### DIFF
--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -52,7 +52,7 @@ config:
 
 crds:
 	mkdir -p deploy/helm/{[ operator.name }]/crds
-	cargo run crd | yq eval '.metadata.annotations["helm.sh/resource-policy"]="keep"' - > deploy/helm/{[ operator.name }]/crds/crds.yaml
+	cargo run --bin stackable-{[ operator.name }] -- crd | yq eval '.metadata.annotations["helm.sh/resource-policy"]="keep"' - > deploy/helm/{[ operator.name }]/crds/crds.yaml
 
 chart-lint: compile-chart
 	docker run -it -v $(shell pwd):/build/helm-charts -w /build/helm-charts quay.io/helmpack/chart-testing:v3.5.0  ct lint --config deploy/helm/ct.yaml

--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -12,6 +12,8 @@ TAG    := $(shell git rev-parse --short HEAD)
 
 VERSION := $(shell cargo metadata --format-version 1 | jq '.packages[] | select(.name=="stackable-{[ operator.name }]") | .version')
 
+SHELL=/bin/bash -euo pipefail
+
 ## Docker related targets
 docker-build:
 	docker build --force-rm -t "docker.stackable.tech/stackable/{[ operator.name }]:${VERSION}" -f docker/Dockerfile .


### PR DESCRIPTION
The current crds target in the Makefile only works for repositories which have a single binary crate.

This failed for the opa operator, as it has two binaries. To make matters worse, this wasn't noticed by make because the output of the cargo command is piped into another command, effectively hiding the error rc.

This PR fixes the crds target to directly specify the binary crate as well as adds an explicit SHELL to the Makefile with pipefail set.


```
opa-operator git:(main) ✗ make crds                                                                                                     <<<
mkdir -p deploy/helm/opa-operator/crds
cargo run crd | yq eval '.metadata.annotations["helm.sh/resource-policy"]="keep"' - > deploy/helm/opa-operator/crds/crds.yaml
error: `cargo run` could not determine which binary to run. Use the `--bin` option to specify a binary, or the `default-run` manifest key.
available binaries: stackable-opa-bundle-builder, stackable-opa-operator
make: *** [Makefile:53: crds] Error 101
(⎈ |gke_engineering-329019_europe-central2-a_elia:default)➜  opa-operator git:(main) ✗ echo $?                                                                                                       <<<
2
```
  