### PR TITLE
Removed detect-secrets check as it produced many false positives

### DIFF
--- a/.github/workflows/reviewdog.yaml
+++ b/.github/workflows/reviewdog.yaml
@@ -18,14 +18,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  detect-secrets:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # tag=v3.0.0
-      - uses: reviewdog/action-detect-secrets@bc7432bf205393ff7453416b3c93853773cee69d # tag=v0.8.1
-        with:
-          github_token: ${{ secrets.github_token }}
-
   flake8:
     runs-on: ubuntu-latest
     steps:

--- a/template/.github/workflows/reviewdog.yaml
+++ b/template/.github/workflows/reviewdog.yaml
@@ -18,14 +18,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  detect-secrets:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # tag=v3.0.0
-      - uses: reviewdog/action-detect-secrets@bc7432bf205393ff7453416b3c93853773cee69d # tag=v0.8.1
-        with:
-          github_token: ${{ secrets.github_token }}
-
   flake8:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Theoretically we should be able to reduce them with the option detect_secrets_flags and --exclude-secrets
See https://github.com/reviewdog/action-detect-secrets and https://github.com/Yelp/detect-secrets
But this didn't work