### PR TITLE
Ignore values.yaml for secret-operator

### DIFF
--- a/playbook/update_repo.yaml
+++ b/playbook/update_repo.yaml
@@ -70,6 +70,7 @@
         block_end_string: "%}]"
       with_items: "{{ files_j2.files }}"
       register: template_result
+      when: item.path | replace(template_dir + '/', '') not in operator.ignored_files | default([])
 
     - name: Copy normal files to temp directory
       copy:
@@ -78,14 +79,14 @@
         dest: "{{ item.path | replace(template_dir, work_dir + '/' + operator.name) | replace('[[operator]]', operator.name)}}"
       with_items: "{{ files_normal.files }}"
       register: file_result
+      when: item.path | replace(template_dir + '/', '') not in operator.ignored_files | default([])
 
     - name: Remove retired files and directories
       file:
         path: "{{ work_dir }}/{{ operator.name }}/{{ item | replace('[[product]]', operator.product_string) }}"
         state: absent
-      with_items: "{{ retired_files }}"
+      with_items: "{{ retired_files | default([]) }}"
       register: deletion_result
-      when: retired_files is defined
 
     - name: Regenerate charts to update version
       command:

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -65,6 +65,8 @@ repositories:
     pretty_string: Stackable Secret Operator
     run_as: custom
     include_productconfig: false
+    ignored_files:
+    - deploy/helm/[[operator]]/values.yaml.j2
 
 # Anything specified in the retired_files variable will be deleted.
 # This is uncommented as I had issues with everything being deleted when this was just present as an empty key.
@@ -79,4 +81,4 @@ retired_files:
   - .github/workflows/rust.yml
   - .github/dependabot.yml
   - python/cargo-version.py
-  - deploy/helm/[[product]]-operator/configs/config-spec
+  - deploy/helm/[[operator]]/configs/config-spec

--- a/repositories.yaml
+++ b/repositories.yaml
@@ -66,7 +66,7 @@ repositories:
     run_as: custom
     include_productconfig: false
     ignored_files:
-    - deploy/helm/[[operator]]/values.yaml.j2
+      - deploy/helm/[[operator]]/values.yaml.j2
 
 # Anything specified in the retired_files variable will be deleted.
 # This is uncommented as I had issues with everything being deleted when this was just present as an empty key.


### PR DESCRIPTION
This is required to avoid having templating revert https://github.com/stackabletech/secret-operator/pull/103. That PR is not suitable to roll out for all operators, since most operators should not need that level of privilege.