### PR TITLE
Add cargo clean step as the github runner started running out of disk space

### DIFF
--- a/playbook/update_repo.yaml
+++ b/playbook/update_repo.yaml
@@ -132,3 +132,9 @@
         chdir: "{{ work_dir }}/{{ operator.name }}"
 
   when: git_change.rc != 0 and branch_exists.rc == 2 # rc of 2 means the branch doesn't exist which is what we want
+
+- name: Clean
+  command:
+    argv: [ cargo, clean ]
+    chdir: "{{ work_dir }}/{{ operator.name }}"
+  tags: local

--- a/playbook/update_repo.yaml
+++ b/playbook/update_repo.yaml
@@ -135,6 +135,6 @@
 
 - name: Clean
   command:
-    argv: [ cargo, clean ]
+    argv: [cargo, clean]
     chdir: "{{ work_dir }}/{{ operator.name }}"
   tags: local


### PR DESCRIPTION
We started running into failures when generating downstream PRs as the github runner started to run out of diskspace due to rust build artefacts accumulating.

This adds a `cargo clean` step at the end of each operator step to clean up state.