### PR TITLE
JQ is a requirement for test scenario templating

### DIFF
--- a/template/tests/README-templating.md
+++ b/template/tests/README-templating.md
@@ -72,6 +72,7 @@ To run tests locally you need the following things installed:
 - python3
   - pyyaml library installed
 - ansible
+- jq
 
 ### Running
 


### PR DESCRIPTION
While adding the capability to run the templated integration tests in Jenkins CI, I noticed that JQ is also a requirement for the tests to run.