### PR TITLE
Add default test parallelism to kuttl definition file.

### DIFF
--- a/template/tests/kuttl-test.yaml.jinja2
+++ b/template/tests/kuttl-test.yaml.jinja2
@@ -8,3 +8,4 @@ testDirs:
 
 startKIND: false
 suppress: ["events"]
+parallel: 2


### PR DESCRIPTION
This reduces the default parallelism of kuttl from 8 to 2, as we have seen sporadic test failures due to test clusters running out of resources.

This value can be overridden by passing a parameter to the run_tests.sh script like follows: `run_tests.sh --parallel 4`

Most ci test defitions make use of this and for personal usage the value that may work here is heavily dependent on the size of the test cluster developers are using, so this will be customized a lot anyway.