### PR TITLE
Allow Unicode-DFS-2016 license

### DIFF
--- a/template/deny.toml.j2
+++ b/template/deny.toml.j2
@@ -30,6 +30,7 @@ allow = [
     "LicenseRef-ring",
     "LicenseRef-webpki",
     "MIT",
+    "Unicode-DFS-2016",
     "Zlib"
 ]
 


### PR DESCRIPTION
Allow Unicode-DFS-2016 license

[unicode-ident](https://crates.io/crates/unicode-ident) which is used by [serde](https://crates.io/crates/serde) added the Unicode-DFS-2016 license in version 1.0.2.