### PR TITLE
Cross platform operator compiling

### DIFF
--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -253,7 +253,7 @@ jobs:
         with:
           submodules: recursive
       - name: Set up Helm
-        uses: azure/setup-helm@199ab446dfa1589521f53f82278b37edff546f3b # tag=v2.2
+        uses: azure/setup-helm@e4f3964f67aac34233ac06d6614802b7040f2a7c # tag=v3.1
         with:
           version: v3.6.2
       - name: Set up cargo

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -346,6 +346,9 @@ jobs:
       - name: Build Docker image
         if: env.NEXUS_PASSWORD != null # pragma: allowlist secret
         run: make docker
+      - name: Build Docker image multi-arch
+        if: env.NEXUS_PASSWORD != null # pragma: allowlist secret
+        run: make docker-build-multi-arch ORG=stackable-experimental
       - name: Publish Chart
         if: env.NEXUS_PASSWORD != null # pragma: allowlist secret
         run: >-

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -341,15 +341,30 @@ jobs:
         run: make chart-clean clean-manifests compile-chart generate-manifests
 
       # Package and publish charts
-      - name: Package Chart
+      -
+        name: Package Chart
         run: mkdir -p target/helm && helm package --destination target/helm deploy/helm/${{ env.OPERATOR_NAME }}
-      - name: Build Docker image
+
+      -
+        name: Build Docker image
         if: env.NEXUS_PASSWORD != null # pragma: allowlist secret
         run: make docker
-      - name: Build Docker image multi-arch
+
+      -
+        name: Set up QEMU for multiarch builds
+        uses: docker/setup-qemu-action@v2
+
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      -
+        name: Build Docker image multi-arch
         if: env.NEXUS_PASSWORD != null # pragma: allowlist secret
         run: make docker-build-multi-arch ORG=stackable-experimental
-      - name: Publish Chart
+
+      -
+        name: Publish Chart
         if: env.NEXUS_PASSWORD != null # pragma: allowlist secret
         run: >-
           /usr/bin/curl

--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -28,13 +28,13 @@ docker-build:
 {[% endif %}]
 
 build-multi-arch:
-    docker buildx build --force-rm --build-arg VERSION=${VERSION} -t "docker.stackable.tech/${ORG}/{[ operator.name }]:${VERSION}" -f docker/Dockerfile --platform linux/arm64,linux/amd64 --push .
+	 docker buildx build --force-rm --build-arg VERSION=${VERSION} -t "docker.stackable.tech/${ORG}/{[ operator.name }]:${VERSION}" -f docker/Dockerfile --platform linux/arm64,linux/amd64 --push .
 {[% if operator.product_string in ['opa'] %}]
 	docker buildx build --force-rm  --build-arg VERSION=${VERSION} -t "docker.stackable.tech/${ORG}/{[ operator.product_string }]-bundle-builder:${VERSION}"" -f docker/Dockerfile --platform linux/arm64,linux/amd64 --push .
 {[% endif %}]
 
 create-builder:
-    docker buildx create --name builder --use
+	docker buildx create --name builder --use
 
 clean-builder:
 	docker buildx rm builder
@@ -43,13 +43,12 @@ docker-login:
 	echo "${NEXUS_PASSWORD}" | docker login --username github --password-stdin docker.stackable.tech
 
 docker-publish:
-	echo "${NEXUS_PASSWORD}" | docker login --username github --password-stdin docker.stackable.tech
 	docker push --all-tags docker.stackable.tech/${ORG}/{[ operator.name }]
 {[% if operator.product_string in ['opa'] %}]
 	docker push --all-tags docker.stackable.tech/${ORG}/{[ operator.product_string }]-bundle-builder
 {[% endif %}]
 
-docker: docker-build docker-publish
+docker: docker-build docker-login docker-publish
 
 docker-multi-arch: create-builder docker-login build-multi-arch clean-builder
 

--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -28,10 +28,10 @@ docker-build:
 {[% endif %}]
 
 build-multi-arch:
-	echo "${NEXUS_PASSWORD}" | docker login --username github --password-stdin docker.stackable.tech
+echo "${NEXUS_PASSWORD}" | docker login --username github --password-stdin docker.stackable.tech
     docker buildx build --force-rm  --build-arg VERSION=${VERSION} -t "docker.stackable.tech/${ORG}/{[ operator.name }]:${VERSION}" -f docker/Dockerfile --platform linux/arm64,linux/amd64 --push .
 {[% if operator.product_string in ['opa'] %}]
-		docker buildx build --force-rm  --build-arg VERSION=${VERSION} -t "docker.stackable.tech/${ORG}/{[ operator.product_string }]-bundle-builder:${VERSION}"" -f docker/Dockerfile --platform linux/arm64,linux/amd64 --push .
+	docker buildx build --force-rm  --build-arg VERSION=${VERSION} -t "docker.stackable.tech/${ORG}/{[ operator.product_string }]-bundle-builder:${VERSION}"" -f docker/Dockerfile --platform linux/arm64,linux/amd64 --push .
 {[% endif %}]
 
 create-builder:

--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -27,11 +27,6 @@ docker-build:
 	docker build --force-rm --build-arg VERSION=${VERSION} -t "docker.stackable.tech/${ORG}/{[ operator.product_string }]-bundle-builder:${VERSION}" -f docker/Dockerfile.builder .
 {[% endif %}]
 
-## Not usefull anymore, got rid of :latest
-docker-build-latest: docker-build
-	docker tag "docker.stackable.tech/${ORG}/{[ operator.name }]:${VERSION}" \
-	           "docker.stackable.tech/${ORG}/{[ operator.name }]:latest"
-
 docker-build-multi-arch:
         docker buildx create --name builder --use
 		echo "${NEXUS_PASSWORD}" | docker login --username github --password-stdin docker.stackable.tech
@@ -51,8 +46,6 @@ docker-publish:
 {[% endif %}]
 
 docker: docker-build docker-publish
-
-docker-release: docker-build-latest docker-publish
 
 ## Chart related targets
 compile-chart: version crds config

--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -15,7 +15,7 @@ IS_NIGHTLY := $(shell echo "${VERSION}" | grep -- '-nightly$$')
 # When rendering docs we want to simplify the version number slightly, only rendering "nightly" for nightly branches
 # (since we only render nightlies for the active development trunk anyway) and chopping off the semver patch version otherwise
 DOCS_VERSION := $(if ${IS_NIGHTLY},nightly,$(shell echo "${VERSION}" | sed 's/^\([0-9]\+\.[0-9]\+\)\..*$$/\1/'))
-ORG = "stackable"
+ORG = stackable
 export VERSION IS_NIGHTLY DOCS_VERSION
 
 SHELL=/bin/bash -euo pipefail
@@ -27,16 +27,18 @@ docker-build:
 	docker build --force-rm --build-arg VERSION=${VERSION} -t "docker.stackable.tech/${ORG}/{[ operator.product_string }]-bundle-builder:${VERSION}" -f docker/Dockerfile.builder .
 {[% endif %}]
 
-docker-build-multi-arch:
-        docker buildx create --name builder --use
-		echo "${NEXUS_PASSWORD}" | docker login --username github --password-stdin docker.stackable.tech
-        docker buildx build --force-rm  --build-arg VERSION=${VERSION} -t "docker.stackable.tech/${ORG}/{[ operator.name }]:${VERSION}" -f docker/Dockerfile --platform linux/arm64,linux/amd64 --push .
+build-multi-arch:
+	echo "${NEXUS_PASSWORD}" | docker login --username github --password-stdin docker.stackable.tech
+    docker buildx build --force-rm  --build-arg VERSION=${VERSION} -t "docker.stackable.tech/${ORG}/{[ operator.name }]:${VERSION}" -f docker/Dockerfile --platform linux/arm64,linux/amd64 --push .
 {[% if operator.product_string in ['opa'] %}]
 		docker buildx build --force-rm  --build-arg VERSION=${VERSION} -t "docker.stackable.tech/${ORG}/{[ operator.product_string }]-bundle-builder:${VERSION}"" -f docker/Dockerfile --platform linux/arm64,linux/amd64 --push .
 {[% endif %}]
 
+create-builder:
+	docker buildx create --name builder --use
+
 clean-builder:
-		docker buildx rm builder
+	docker buildx rm builder
 
 docker-publish:
 	echo "${NEXUS_PASSWORD}" | docker login --username github --password-stdin docker.stackable.tech
@@ -46,6 +48,8 @@ docker-publish:
 {[% endif %}]
 
 docker: docker-build docker-publish
+
+docker-multi-arch: create-builder build-multi-arch clean-builder
 
 ## Chart related targets
 compile-chart: version crds config

--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -28,7 +28,7 @@ docker-build:
 {[% endif %}]
 
 build-multi-arch:
-    docker buildx build --force-rm  --build-arg VERSION=${VERSION} -t "docker.stackable.tech/${ORG}/{[ operator.name }]:${VERSION}" -f docker/Dockerfile --platform linux/arm64,linux/amd64 --push .
+    docker buildx build --force-rm --build-arg VERSION=${VERSION} -t "docker.stackable.tech/${ORG}/{[ operator.name }]:${VERSION}" -f docker/Dockerfile --platform linux/arm64,linux/amd64 --push .
 {[% if operator.product_string in ['opa'] %}]
 	docker buildx build --force-rm  --build-arg VERSION=${VERSION} -t "docker.stackable.tech/${ORG}/{[ operator.product_string }]-bundle-builder:${VERSION}"" -f docker/Dockerfile --platform linux/arm64,linux/amd64 --push .
 {[% endif %}]
@@ -51,7 +51,7 @@ docker-publish:
 
 docker: docker-build docker-publish
 
-docker-multi-arch: create-builder build-multi-arch clean-builder
+docker-multi-arch: create-builder docker-login build-multi-arch clean-builder
 
 ## Chart related targets
 compile-chart: version crds config

--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -28,17 +28,19 @@ docker-build:
 {[% endif %}]
 
 build-multi-arch:
-	echo "${NEXUS_PASSWORD}" | docker login --username github --password-stdin docker.stackable.tech
     docker buildx build --force-rm  --build-arg VERSION=${VERSION} -t "docker.stackable.tech/${ORG}/{[ operator.name }]:${VERSION}" -f docker/Dockerfile --platform linux/arm64,linux/amd64 --push .
 {[% if operator.product_string in ['opa'] %}]
 	docker buildx build --force-rm  --build-arg VERSION=${VERSION} -t "docker.stackable.tech/${ORG}/{[ operator.product_string }]-bundle-builder:${VERSION}"" -f docker/Dockerfile --platform linux/arm64,linux/amd64 --push .
 {[% endif %}]
 
 create-builder:
-	docker buildx create --name builder --use
+    docker buildx create --name builder --use
 
 clean-builder:
 	docker buildx rm builder
+
+docker-login:
+	echo "${NEXUS_PASSWORD}" | docker login --username github --password-stdin docker.stackable.tech
 
 docker-publish:
 	echo "${NEXUS_PASSWORD}" | docker login --username github --password-stdin docker.stackable.tech

--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -28,7 +28,7 @@ docker-build:
 {[% endif %}]
 
 build-multi-arch:
-echo "${NEXUS_PASSWORD}" | docker login --username github --password-stdin docker.stackable.tech
+	echo "${NEXUS_PASSWORD}" | docker login --username github --password-stdin docker.stackable.tech
     docker buildx build --force-rm  --build-arg VERSION=${VERSION} -t "docker.stackable.tech/${ORG}/{[ operator.name }]:${VERSION}" -f docker/Dockerfile --platform linux/arm64,linux/amd64 --push .
 {[% if operator.product_string in ['opa'] %}]
 	docker buildx build --force-rm  --build-arg VERSION=${VERSION} -t "docker.stackable.tech/${ORG}/{[ operator.product_string }]-bundle-builder:${VERSION}"" -f docker/Dockerfile --platform linux/arm64,linux/amd64 --push .

--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -15,26 +15,39 @@ IS_NIGHTLY := $(shell echo "${VERSION}" | grep -- '-nightly$$')
 # When rendering docs we want to simplify the version number slightly, only rendering "nightly" for nightly branches
 # (since we only render nightlies for the active development trunk anyway) and chopping off the semver patch version otherwise
 DOCS_VERSION := $(if ${IS_NIGHTLY},nightly,$(shell echo "${VERSION}" | sed 's/^\([0-9]\+\.[0-9]\+\)\..*$$/\1/'))
+ORG = "stackable"
 export VERSION IS_NIGHTLY DOCS_VERSION
 
 SHELL=/bin/bash -euo pipefail
 
 ## Docker related targets
 docker-build:
-	docker build --force-rm --build-arg VERSION=${VERSION} -t "docker.stackable.tech/stackable/{[ operator.name }]:${VERSION}" -f docker/Dockerfile .
+	docker build --force-rm --build-arg VERSION=${VERSION} -t "docker.stackable.tech/${ORG}/{[ operator.name }]:${VERSION}" -f docker/Dockerfile .
 {[% if operator.product_string in ['opa'] %}]
-	docker build --force-rm --build-arg VERSION=${VERSION} -t "docker.stackable.tech/stackable/{[ operator.product_string }]-bundle-builder:${VERSION}" -f docker/Dockerfile.builder .
+	docker build --force-rm --build-arg VERSION=${VERSION} -t "docker.stackable.tech/${ORG}/{[ operator.product_string }]-bundle-builder:${VERSION}" -f docker/Dockerfile.builder .
 {[% endif %}]
 
+## Not usefull anymore, got rid of :latest
 docker-build-latest: docker-build
-	docker tag "docker.stackable.tech/stackable/{[ operator.name }]:${VERSION}" \
-	           "docker.stackable.tech/stackable/{[ operator.name }]:latest"
+	docker tag "docker.stackable.tech/${ORG}/{[ operator.name }]:${VERSION}" \
+	           "docker.stackable.tech/${ORG}/{[ operator.name }]:latest"
+
+docker-build-multi-arch:
+        docker buildx create --name builder --use
+		echo "${NEXUS_PASSWORD}" | docker login --username github --password-stdin docker.stackable.tech
+        docker buildx build --force-rm  --build-arg VERSION=${VERSION} -t "docker.stackable.tech/${ORG}/{[ operator.name }]:${VERSION}" -f docker/Dockerfile --platform linux/arm64,linux/amd64 --push .
+{[% if operator.product_string in ['opa'] %}]
+		docker buildx build --force-rm  --build-arg VERSION=${VERSION} -t "docker.stackable.tech/${ORG}/{[ operator.product_string }]-bundle-builder:${VERSION}"" -f docker/Dockerfile --platform linux/arm64,linux/amd64 --push .
+{[% endif %}]
+
+clean-builder:
+		docker buildx rm builder
 
 docker-publish:
 	echo "${NEXUS_PASSWORD}" | docker login --username github --password-stdin docker.stackable.tech
-	docker push --all-tags docker.stackable.tech/stackable/{[ operator.name }]
+	docker push --all-tags docker.stackable.tech/${ORG}/{[ operator.name }]
 {[% if operator.product_string in ['opa'] %}]
-	docker push --all-tags docker.stackable.tech/stackable/{[ operator.product_string }]-bundle-builder
+	docker push --all-tags docker.stackable.tech/${ORG}/{[ operator.product_string }]-bundle-builder
 {[% endif %}]
 
 docker: docker-build docker-publish


### PR DESCRIPTION
Made multi-arch builds possible.

In Makefile.j2:
Added docker-build-mulit-arch as an additional possibility to use make, multi-arch images will be build there. 

In build.yml.j2:
A new job for build, will be executed in addition to single arch images.