### PR TITLE
Configure yamllint to accept non-indented sequences

### DIFF
--- a/template/.yamllint.yaml
+++ b/template/.yamllint.yaml
@@ -10,3 +10,5 @@ rules:
     check-keys: false
   comments:
     min-spaces-from-content: 1  # Needed due to https://github.com/adrienverge/yamllint/issues/443
+  indentation:
+    indent-sequences: consistent


### PR DESCRIPTION
Configure yamllint to accept non-indented sequences

`serde_yaml:0.9` does not indent sequences anymore, so yamllint should not complain about it.