### PR TITLE
Don't assume that bash is at /bin/bash

### DIFF
--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -17,7 +17,7 @@ IS_NIGHTLY := $(shell echo "${VERSION}" | grep -- '-nightly$$')
 DOCS_VERSION := $(if ${IS_NIGHTLY},nightly,$(shell echo "${VERSION}" | sed 's/^\([0-9]\+\.[0-9]\+\)\..*$$/\1/'))
 export VERSION IS_NIGHTLY DOCS_VERSION
 
-SHELL=/bin/bash -euo pipefail
+SHELL=/usr/bin/env bash -euo pipefail
 
 ## Docker related targets
 docker-build:


### PR DESCRIPTION
This broke the build on NixOS, which _only_ provides /bin/sh and /usr/bin/env, and expects everything else to be found on the $PATH.