### PR TITLE
Install protoc in the GitHub workflows

### DIFF
--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -33,6 +33,10 @@ jobs:
     env:
       RUSTC_BOOTSTRAP: 1
     steps:
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install protobuf-compiler
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
         with:
           submodules: recursive
@@ -158,6 +162,10 @@ jobs:
     name: Run Clippy
     runs-on: ubuntu-latest
     steps:
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install protobuf-compiler
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
         with:
           submodules: recursive
@@ -188,6 +196,10 @@ jobs:
     name: Run RustDoc
     runs-on: ubuntu-latest
     steps:
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install protobuf-compiler
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
         with:
           submodules: recursive
@@ -214,6 +226,10 @@ jobs:
       - run_rustdoc
     runs-on: ubuntu-latest
     steps:
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install protobuf-compiler
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
         with:
           submodules: recursive
@@ -248,6 +264,10 @@ jobs:
       - run_rustdoc
     runs-on: ubuntu-latest
     steps:
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install protobuf-compiler
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
         with:
@@ -312,6 +332,10 @@ jobs:
       REPO: ${{ needs.select_repo.outputs.repository }}
     if: needs.select_repo.outputs.repository != 'skip'
     steps:
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install protobuf-compiler
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
         with:


### PR DESCRIPTION
Install protoc in the GitHub workflows

The secret-operator depends on [`prost`](https://crates.io/crates/prost), a Protocol Buffers implementation for Rust. With version 0.11, `prost` will no longer provide a bundled `protoc`. Therefore `protoc` must be installed on the build runners.