### PR TITLE
Ignore license checks for all private crates

### DIFF
--- a/template/deny.toml
+++ b/template/deny.toml
@@ -33,14 +33,7 @@ allow = [
     "Unicode-DFS-2016",
     "Zlib"
 ]
-
-exceptions = [
-    { name = "stackable-{[ operator.product_string }]-crd", allow = ["OSL-3.0"] },
-    { name = "stackable-{[ operator.name }]", allow = ["OSL-3.0"] },
-    { name = "stackable-{[ operator.name }]-binary", allow = ["OSL-3.0"] },
-    {[% if operator.extra_crates is not undefined %}]{[% for crate in operator.extra_crates %}]{ name = "{[crate}]", allow = ["OSL-3.0"] },
-    {[% endfor %}]{[% endif -%}]
-]
+private = { ignore = true }
 
 [[licenses.clarify]]
 name = "ring"


### PR DESCRIPTION
See https://stackable-workspace.slack.com/archives/C02FZ581UCD/p1664368256835939 for discussion.

This replaces the explicit allowlist with a generic ignore for all private crates, which should cut down on the spurious warnings (for operators that don't follow the "3-crate structure") and allow operator-specific utility crates to pass checks.

This will require the property `package.publish = false` to be set for each crate's `Cargo.toml` when merging the templating PRs. For example, for airflow-operator the following patch has to be applied:

```diff
diff --git a/rust/crd/Cargo.toml b/rust/crd/Cargo.toml
index 50a9ff9..4efdc59 100644
--- a/rust/crd/Cargo.toml
+++ b/rust/crd/Cargo.toml
@@ -6,6 +6,7 @@ license = "OSL-3.0"
 name = "stackable-airflow-crd"
 repository = "https://github.com/stackabletech/airflow-operator"
 version = "0.6.0-nightly"
+publish = false
 
 [dependencies]
 serde = "1.0"
diff --git a/rust/operator-binary/Cargo.toml b/rust/operator-binary/Cargo.toml
index b1e53c8..900bd2b 100644
--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -6,6 +6,7 @@ license = "OSL-3.0"
 version = "0.6.0-nightly"
 edition = "2021"
 repository = "https://github.com/stackabletech/airflow-operator"
+publish = false
 
 [dependencies]
 anyhow = "1.0"
```

Thanks to @fhennig for finding this mechanism.