### PR TITLE
Stop installing the GH CLI in CI

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -24,12 +24,6 @@ jobs:
             sudo apt-add-repository ppa:ansible/ansible -y && \
             sudo apt install -y ansible
 
-      - name: Install Github CLI
-        run: |
-            sudo curl --output /opt/gh.deb https://repo.stackable.tech/repository/packages/gh/gh_2.14.7_linux_amd64.deb && \
-            sudo apt-get install /opt/gh.deb && \
-            sudo rm /opt/gh.deb
-
       - name: Install protoc
         run: |
           sudo apt-get install protobuf-compiler


### PR DESCRIPTION
This has been causing CI failures the last few days since GH Actions now apparently includes a newer version in their image anyway. See https://github.com/stackabletech/operator-templating/actions/runs/3143897301/jobs/5109201435#step:4:19