### PR TITLE
Fix README badge regression

### DIFF
--- a/template/.readme/partials/borrowed/links.md.j2.j2
+++ b/template/.readme/partials/borrowed/links.md.j2.j2
@@ -1,4 +1,5 @@
-{# NOTE: the empty line produced by this comment is important -#}
+
+{# NOTE: the empty line above is important! -#}
 {% if no_jenkins_job_badge %}{% else %}[![Build Actions Status](https://ci.stackable.tech/job/{{operator_name}}%2doperator%2dit%2dnightly/badge/icon?subject=Integration%20Tests)](https://ci.stackable.tech/job/{{operator_name}}%2doperator%2dit%2dnightly){% endif %}
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://GitHub.com/stackabletech/{{operator_name}}-operator/graphs/commit-activity)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-green.svg)](https://docs.stackable.tech/home/stable/contributor/index.html)


### PR DESCRIPTION
Turns out that a line with a comment gets removed during rendering, instead of leaving behind one _essential_ blank line.