### PR TITLE
Fix incorrect README docs links

### DIFF
--- a/template/.readme/partials/borrowed/documentation.md.j2.j2
+++ b/template/.readme/partials/borrowed/documentation.md.j2.j2
@@ -1,7 +1,7 @@
 ## Documentation
 
-The stable documentation for this operator can be found [here](https://docs.stackable.tech/{{operator_name}}/stable/index.html).
-If you are interested in the most recent state of this repository, check out the [nightly docs](https://docs.stackable.tech/{{operator_name}}/nightly/index.html) instead.
+The stable documentation for this operator can be found [here](https://docs.stackable.tech/{{operator_docs_slug}}/stable/index.html).
+If you are interested in the most recent state of this repository, check out the [nightly docs](https://docs.stackable.tech/{{operator_docs_slug}}/nightly/index.html) instead.
 
 The documentation for all Stackable products can be found at [docs.stackable.tech](https://docs.stackable.tech).
 

--- a/template/.readme/partials/borrowed/links.md.j2.j2
+++ b/template/.readme/partials/borrowed/links.md.j2.j2
@@ -5,4 +5,4 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-green.svg)](https://docs.stackable.tech/home/stable/contributor/index.html)
 [![License OSL3.0](https://img.shields.io/badge/license-OSL3.0-green)](./LICENSE)
 
-[Documentation](https://docs.stackable.tech/{{operator_name}}-operator/stable/index.html) {% if quickstart_link %}| [Quickstart]({{quickstart_link}}) {% endif %}| [Stackable Data Platform](https://stackable.tech/) | [Platform Docs](https://docs.stackable.tech/) | [Discussions](https://github.com/orgs/stackabletech/discussions)
+[Documentation](https://docs.stackable.tech/{{operator_docs_slug}}/stable/index.html) {% if quickstart_link %}| [Quickstart]({{quickstart_link}}) {% endif %}| [Stackable Data Platform](https://stackable.tech/) | [Platform Docs](https://docs.stackable.tech/) | [Discussions](https://github.com/orgs/stackabletech/discussions)


### PR DESCRIPTION
The operator doc paths differ from the repository names, and require a separate variable, set per operator.