### PR TITLE
CircleCI config for building multi-arch operator images

### DIFF
--- a/template/.circleci/config.yaml
+++ b/template/.circleci/config.yaml
@@ -5,13 +5,13 @@ version: 2.1
 parameters:
   docker-registry-username:
     type: string
-    default: "vladislav.supalov"
+    default: "github"
   docker-registry-org:
     type: string
-    default: "vsupalov"
+    default: "stackable-experimental"
   operator-name:
     type: string
-    default: "druid-operator"
+    default: "{[ operator.name }]"
 orbs:
   jq: circleci/jq@2.2.0
 jobs:

--- a/template/.circleci/config.yaml
+++ b/template/.circleci/config.yaml
@@ -100,14 +100,13 @@ jobs:
 workflows:
   version: 2
   build_multiarch:
-    #TODO: context, org-global for secrets so they don't need to be handled per project?
     jobs:
       - construct_version_string:
           # NOTE: this filter prevents everything else from running, due to 'requires' constraints
           filters:
             branches:
               only:
-                - arm-circleci
+                - main
       - build_and_push_amd:
           requires:
             - construct_version_string

--- a/template/.circleci/config.yaml
+++ b/template/.circleci/config.yaml
@@ -1,0 +1,126 @@
+# NOTE: all the echoing to BASH_ENV is due to circleCI not being able to interpolate vars
+# https://circleci.com/docs/set-environment-variable/
+
+version: 2.1
+parameters:
+  docker-registry-username:
+    type: string
+    default: "vladislav.supalov"
+  docker-registry-org:
+    type: string
+    default: "vsupalov"
+  operator-name:
+    type: string
+    default: "druid-operator"
+orbs:
+  jq: circleci/jq@2.2.0
+jobs:
+  construct_version_string:
+    docker:
+      # https://circleci.com/developer/images/image/cimg/rust
+      - image: cimg/rust:1.65.0
+    steps:
+      - checkout
+      - jq/install
+      - run: mkdir -p workspace
+      - run: cargo metadata --format-version 1 | jq -r '.packages[] | select(.name=="stackable-<<pipeline.parameters.operator-name>>") | .version' > workspace/version
+      # persist resulting file for future steps
+      # https://circleci.com/docs/workspaces/
+      - persist_to_workspace:
+          root: workspace
+          paths:
+            - version
+  build_and_push_amd:
+    machine:
+      image: ubuntu-2004:202010-01 # recommended linux image
+    resource_class: large
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Set environment variables
+          command: |
+            echo 'export VERSION=$(cat /tmp/workspace/version)' >> "$BASH_ENV"
+            echo 'export TAG=$(cat /tmp/workspace/version)-amd' >> "$BASH_ENV"
+            source "$BASH_ENV"
+      - run:
+          name: Build Docker image
+          command: |
+            docker build --force-rm --build-arg ORG_NAME=<<pipeline.parameters.docker-registry-org>> --build-arg VERSION=${VERSION} -t "docker.stackable.tech/<<pipeline.parameters.docker-registry-org>>/<<pipeline.parameters.operator-name>>:${TAG}" -f docker/Dockerfile .
+      - run:
+          name: Push Docker image
+          command: |
+            echo "${NEXUS_PASSWORD}" | docker login --username <<pipeline.parameters.docker-registry-username>> --password-stdin docker.stackable.tech
+            docker push docker.stackable.tech/<<pipeline.parameters.docker-registry-org>>/<<pipeline.parameters.operator-name>>:${TAG}
+  build_and_push_arm:
+    # https://circleci.com/docs/using-arm/
+    machine:
+      image: ubuntu-2004:202101-01 # https://circleci.com/docs/configuration-reference/#machine
+    resource_class: arm.large
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Set environment variables
+          command: |
+            echo 'export VERSION=$(cat /tmp/workspace/version)' >> "$BASH_ENV"
+            echo 'export TAG=$(cat /tmp/workspace/version)-arm' >> "$BASH_ENV"
+            source "$BASH_ENV"
+      - run:
+          name: Build Docker image
+          command: |
+            docker build --force-rm --build-arg ORG_NAME=<<pipeline.parameters.docker-registry-org>> --build-arg VERSION=${VERSION} -t "docker.stackable.tech/<<pipeline.parameters.docker-registry-org>>/<<pipeline.parameters.operator-name>>:${TAG}" -f docker/Dockerfile .
+      - run:
+          name: Push Docker image
+          command: |
+            echo "${NEXUS_PASSWORD}" | docker login --username <<pipeline.parameters.docker-registry-username>> --password-stdin docker.stackable.tech
+            docker push docker.stackable.tech/<<pipeline.parameters.docker-registry-org>>/<<pipeline.parameters.operator-name>>:${TAG}
+  create_multiarch_manifest:
+    docker:
+      - image: cimg/base:2022.06
+    steps:
+      - setup_remote_docker:
+          version: 20.10.14
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Set environment variables
+          command: |
+            echo 'export IMAGE_NAME=docker.stackable.tech/<<pipeline.parameters.docker-registry-org>>/<<pipeline.parameters.operator-name>>:$(cat /tmp/workspace/version)' >> "$BASH_ENV"
+            source "$BASH_ENV"
+      - run:
+          name: Create and push combined Docker manifest
+          command: |
+            echo "${NEXUS_PASSWORD}" | docker login --username <<pipeline.parameters.docker-registry-username>> --password-stdin docker.stackable.tech
+            export DOCKER_CLI_EXPERIMENTAL=enabled # needed, because handling manifests is an experimental feature
+            docker manifest create ${IMAGE_NAME} --amend ${IMAGE_NAME}-amd --amend ${IMAGE_NAME}-arm
+            docker manifest push ${IMAGE_NAME}
+workflows:
+  version: 2
+  build_multiarch:
+    #TODO: context, org-global for secrets so they don't need to be handled per project?
+    jobs:
+      - construct_version_string:
+          # NOTE: this filter prevents everything else from running, due to 'requires' constraints
+          filters:
+            branches:
+              only:
+                - arm-circleci
+      - build_and_push_amd:
+          requires:
+            - construct_version_string
+          context:
+            - org-global
+      - build_and_push_arm:
+          requires:
+            - construct_version_string
+          context:
+            - org-global
+      - create_multiarch_manifest:
+          requires:
+            - build_and_push_amd
+            - build_and_push_arm
+          context:
+            - org-global


### PR DESCRIPTION
As CircleCI offers non-emulated [ARM compute](https://circleci.com/execution-environments/arm/), we can use it to build multi-arch images without having to jump through lots of hoops.

The templated config, a minor Dockerfile change, and a few manual steps on CircleCI to enable each repository, will be enough to establish working multi-arch image build pipelines for all stackable operators.

## Overview

* Images are only built for commits to the main branch of an operator.
* An image is pushed per architecture, and then "connected" in a single tag via Docker manifests.
* No tests are executed here. We assume that whatever lands in main is sufficiently tested for AMD, and let Jesus take the wheel when it comes to ARM validity for now.
* The workflow needs about 11 minutes to complete. No caching is used at the moment.

## Setting up CircleCI

* A paid plan could make sense, but isn't required
* Create a "context" called `org-global`.
* Create an environment variable in the newly created context, called `NEXUS_PASSWORD`. Set the value to the password of our Nexus "github" user.
* Once the template PR of this change is merged in each respective operator, enable their repository in the CircleCI interface.

## Current blockers to multi-arch Stackable

Multi-arch images for our products are being built using [QEMU with GitHub Actions](https://github.com/stackabletech/docker-images/blob/main/.github/workflows/product_images.yml#L112).

At the moment, the resulting images should not be arm64, as the pinning of image hashes (like `FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6@sha256:c5ffdf5938d73283cec018f2adf59f0ed9f8c376d93e415a27b16c3c6aad6f45 AS builder`), to my best knowledge, should result in using an amd64 image.

You can verify this with

```
docker pull registry.access.redhat.com/ubi8/ubi-minimal:8.6@sha256:c5ffdf5938d73283cec018f2adf59f0ed9f8c376d93e415a27b16c3c6aad6f45
docker inspect registry.access.redhat.com/ubi8/ubi-minimal:8.6@sha256:c5ffdf5938d73283cec018f2adf59f0ed9f8c376d93e415a27b16c3c6aad6f45
```

The inspect command will show `"Architecture": "amd64",`, which is an invalid pin to build arm64 images.

If we want our product to be truly multi-arch, we will need to resolve this issue.