### PR TITLE
Fix Ansible warnings

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -1,50 +1,50 @@
 ---
 repositories:
-#  - name: airflow-operator
-#    pretty_string: Apache Airflow
-#    product_string: airflow
-#    url: stackabletech/airflow-operator.git
+  - name: airflow-operator
+    pretty_string: Apache Airflow
+    product_string: airflow
+    url: stackabletech/airflow-operator.git
   - name: commons-operator
     include_productconfig: false
     pretty_string: Stackable Commons
     product_string: commons
     url: stackabletech/commons-operator.git
-#  - name: druid-operator
-#    pretty_string: Apache Druid
-#    product_string: druid
-#    url: stackabletech/druid-operator.git
-#  - name: hbase-operator
-#    pretty_string: Apache HBase
-#    product_string: hbase
-#    url: stackabletech/hbase-operator.git
-#  - name: hdfs-operator
-#    pretty_string: Apache HDFS
-#    product_string: hdfs
-#    url: stackabletech/hdfs-operator.git
-#  - name: hive-operator
-#    pretty_string: Apache Hive
-#    product_string: hive
-#    url: stackabletech/hive-operator.git
-#  - name: kafka-operator
-#    pretty_string: Apache Kafka
-#    product_string: kafka
-#    url: stackabletech/kafka-operator.git
-#  - name: nifi-operator
-#    pretty_string: Apache NiFi
-#    product_string: nifi
-#    url: stackabletech/nifi-operator.git
-#  - name: listener-operator
-#    include_productconfig: false
-#    pretty_string: Stackable Listener Operator
-#    product_string: listener-operator
-#    run_as: custom
-#    url: stackabletech/listener-operator.git
-#  - name: opa-operator
-#    extra_crates:
-#      - stackable-opa-bundle-builder
-#    pretty_string: OpenPolicyAgent
-#    product_string: opa
-#    url: stackabletech/opa-operator.git
+  - name: druid-operator
+    pretty_string: Apache Druid
+    product_string: druid
+    url: stackabletech/druid-operator.git
+  - name: hbase-operator
+    pretty_string: Apache HBase
+    product_string: hbase
+    url: stackabletech/hbase-operator.git
+  - name: hdfs-operator
+    pretty_string: Apache HDFS
+    product_string: hdfs
+    url: stackabletech/hdfs-operator.git
+  - name: hive-operator
+    pretty_string: Apache Hive
+    product_string: hive
+    url: stackabletech/hive-operator.git
+  - name: kafka-operator
+    pretty_string: Apache Kafka
+    product_string: kafka
+    url: stackabletech/kafka-operator.git
+  - name: nifi-operator
+    pretty_string: Apache NiFi
+    product_string: nifi
+    url: stackabletech/nifi-operator.git
+  - name: listener-operator
+    include_productconfig: false
+    pretty_string: Stackable Listener Operator
+    product_string: listener-operator
+    run_as: custom
+    url: stackabletech/listener-operator.git
+  - name: opa-operator
+    extra_crates:
+      - stackable-opa-bundle-builder
+    pretty_string: OpenPolicyAgent
+    product_string: opa
+    url: stackabletech/opa-operator.git
   - name: secret-operator
     include_productconfig: false
     pretty_string: Stackable Secret Operator

--- a/template/scripts/run_tests.sh
+++ b/template/scripts/run_tests.sh
@@ -20,7 +20,7 @@ ansible-galaxy role install -r requirements.yaml -p ./roles
 echo '{}' | jq '{work_dir: $WORKDIR, test_dir: $TESTDIR}' --arg WORKDIR "$WORKDIR" --arg TESTDIR "$TESTDIR" > "${WORKDIR}"/vars.json
 
 # Run playbook to generate test scenarios
-ansible-playbook playbook.yaml --extra-vars "@${WORKDIR}/vars.json"
+ansible-playbook --connection=local --inventory localhost, playbook.yaml --extra-vars "@${WORKDIR}/vars.json"
 popd
 
 # Run tests

--- a/template/tests/ansible/playbook.yaml
+++ b/template/tests/ansible/playbook.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Expand test templates into test scenarios by applying input dimensions
-  hosts: localhost
-  connection: local
+  hosts: all
+  gather_facts: false
   roles:
     - expand-tests


### PR DESCRIPTION
Fixes the following warning when generating kuttl tests:
```
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks instead. This feature will be removed in version 2.16. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
```