### PR TITLE
Integration Test Badge works with anonymous access to Jenkins.

### DIFF
--- a/template/.readme/partials/borrowed/links.md.j2.j2
+++ b/template/.readme/partials/borrowed/links.md.j2.j2
@@ -1,6 +1,6 @@
 
 {# NOTE: the empty line above is important! -#}
-{% if no_jenkins_job_badge %}{% else %}[![Build Actions Status](https://ci.stackable.tech/job/{{operator_name}}%2doperator%2dit%2dnightly/badge/icon?subject=Integration%20Tests)](https://ci.stackable.tech/job/{{operator_name}}%2doperator%2dit%2dnightly){% endif %}
+{% if no_jenkins_job_badge %}{% else %}![Build Actions Status](https://ci.stackable.tech/buildStatus/icon?job={{operator_name}}%2doperator%2dit%2dnightly&subject=Integration%20Tests){% endif %}
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://GitHub.com/stackabletech/{{operator_name}}-operator/graphs/commit-activity)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-green.svg)](https://docs.stackable.tech/home/stable/contributor/index.html)
 [![License OSL3.0](https://img.shields.io/badge/license-OSL3.0-green)](./LICENSE)


### PR DESCRIPTION
The Jenkins jobs are no longer publicly viewable which also affected the visibility of the badges shown in the Operator READMEs. Jenkins allows the visibility being set to "only status" which requires to change the URL a little.
The badge no longer links to the Jenkins job as this would lead to a 404.