### PR TITLE
Migrated test expansion from Ansible to beku.py

### DIFF
--- a/template/.gitignore.j2
+++ b/template/.gitignore.j2
@@ -1,4 +1,3 @@
-tests/ansible/roles/
 tests/_work/
 debug/
 target/

--- a/template/scripts/run_tests.sh
+++ b/template/scripts/run_tests.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
-set -e
 
-# Install and run beku, the tool to expand the test templates
-# (https://github.com/stackabletech/beku.py)
-pip install beku-stackabletech
+# Check if the test expansion tool beku is installed
+set +e
+which beku 2>&1 >/dev/null
+beku_installed=$?
+set -e
+if [ $beku_installed -ne 0 ]; then
+  echo "Please install beku.py to run the tests, see https://github.com/stackabletech/beku.py"
+  exit 1
+fi
+
+# Expand the tests
 beku
 
 # Run tests, pass the params

--- a/template/scripts/run_tests.sh
+++ b/template/scripts/run_tests.sh
@@ -2,7 +2,7 @@
 
 # Check if the test expansion tool beku is installed
 set +e
-which beku 2>&1 >/dev/null
+which beku > /dev/null 2>&1
 beku_installed=$?
 set -e
 if [ $beku_installed -ne 0 ]; then

--- a/template/scripts/run_tests.sh
+++ b/template/scripts/run_tests.sh
@@ -1,29 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
-# Register absolute paths to pass to Ansible so the location of the role is irrelevant
-# for the run
-TESTDIR="$(pwd)/tests"
-WORKDIR="$(pwd)/tests/_work"
+# Install and run beku, the tool to expand the test templates
+# (https://github.com/stackabletech/beku.py)
+pip install beku-stackabletech
+beku
 
-# Create dirs
-mkdir -p tests/ansible/roles
-mkdir -p "$WORKDIR"
-
-# Install Ansible role if needed
-pushd tests/ansible
-ansible-galaxy role install -r requirements.yaml -p ./roles
-
-# TODO: create pipenv in files for script thingy
-
-# Funnel via JSON to ensure that values are escaped properly
-echo '{}' | jq '{work_dir: $WORKDIR, test_dir: $TESTDIR}' --arg WORKDIR "$WORKDIR" --arg TESTDIR "$TESTDIR" > "${WORKDIR}"/vars.json
-
-# Run playbook to generate test scenarios
-ansible-playbook playbook.yaml --extra-vars "@${WORKDIR}/vars.json"
-popd
-
-# Run tests
+# Run tests, pass the params
 pushd tests/_work
 kubectl kuttl test "$@"
 popd

--- a/template/tests/README-templating.md
+++ b/template/tests/README-templating.md
@@ -71,7 +71,6 @@ To run tests locally you need the following things installed:
 
 - python3 (version >= 3.9)
   - pyyaml library installed
-- ansible (tested with `2.10.8` and `2.12.5`)
 - jq
 
 ### Running
@@ -80,4 +79,4 @@ To run tests please execute the following command from the gitroot of the operat
 
 `scripts/run_tests.sh --parallel 2`
 
-This will install the necessary ansible role into `tests/ansible/roles`, expand the test templates into all defined test scenarios and execute kuttl to test these scenarios. Any arguments are passed on to `kuttl`.
+This will expand the test templates into all defined test scenarios and execute kuttl to test these scenarios. Any arguments are passed on to `kuttl`.

--- a/template/tests/ansible/playbook.yaml
+++ b/template/tests/ansible/playbook.yaml
@@ -1,6 +1,0 @@
----
-- name: Expand test templates into test scenarios by applying input dimensions
-  hosts: localhost
-  connection: local
-  roles:
-    - expand-tests

--- a/template/tests/ansible/requirements.yaml
+++ b/template/tests/ansible/requirements.yaml
@@ -1,4 +1,0 @@
----
-- name: expand-tests
-  src: https://github.com/stackabletech/expand-tests.git
-  scm: git


### PR DESCRIPTION
The expansion of the Kuttl templates is done by beku.py now. 

(see https://github.com/stackabletech/issues/issues/315 for details)