### PR TITLE
Tests: cleanup workdir before creating testsuite.

### DIFF
--- a/template/scripts/run_tests.sh
+++ b/template/scripts/run_tests.sh
@@ -10,7 +10,7 @@ if [ $beku_installed -ne 0 ]; then
   exit 1
 fi
 
-echo "Using beku version: $(pip list --disable-pip-version-check | grep beku)"
+echo "Using beku version: $(beku --version)"
 
 # cleanup any old tests
 rm -rf tests/_work

--- a/template/scripts/run_tests.sh
+++ b/template/scripts/run_tests.sh
@@ -10,6 +10,11 @@ if [ $beku_installed -ne 0 ]; then
   exit 1
 fi
 
+echo "Using beku version: $(pip list --disable-pip-version-check | grep beku)"
+
+# cleanup any old tests
+rm -rf tests/_work
+
 # Expand the tests
 beku
 


### PR DESCRIPTION
Small improvement to usage of beku.py:

* cleanup of the old testsuite
* print out the beku.py version

(see https://github.com/stackabletech/issues/issues/315 for details)