### PR TITLE
Update Tiltfile to enable users overriding the default registry with custom values

### DIFF
--- a/template/.gitignore.j2
+++ b/template/.gitignore.j2
@@ -13,3 +13,5 @@ Cargo.nix
 crate-hashes.json
 result
 image.tar
+
+tilt_options.json

--- a/template/Tiltfile
+++ b/template/Tiltfile
@@ -1,5 +1,8 @@
+# If tilt_options.json exists read it and load the default_registry value from it
 settings = read_json('tilt_options.json', default={})
 registry = settings.get('default_registry', 'docker.stackable.tech/sandbox')
+
+# Configure default registry either read from config file above, or with default value of "docker.stackable.tech/sandbox"
 default_registry(registry)
 
 meta = read_json('nix/meta.json')

--- a/template/Tiltfile
+++ b/template/Tiltfile
@@ -1,10 +1,12 @@
-default_registry("docker.stackable.tech/sandbox")
+settings = read_json('tilt_options.json', default={})
+registry = settings.get('default_registry', 'docker.stackable.tech/sandbox')
+default_registry(registry)
 
 meta = read_json('nix/meta.json')
 operator_name = meta['operator']['name']
 
 custom_build(
-    'docker.stackable.tech/sandbox/' + operator_name,
+    registry + '/' + operator_name,
     'nix shell -f . crate2nix -c crate2nix generate && nix-build . -A docker --argstr dockerName "${EXPECTED_REGISTRY}/' + operator_name + '" && ./result/load-image | docker load',
     deps=['rust', 'Cargo.toml', 'Cargo.lock', 'default.nix', "nix", 'build.rs', 'vendor'],
     # ignore=['result*', 'Cargo.nix', 'target', *.yaml],
@@ -22,7 +24,7 @@ helm_crds, helm_non_crds = filter_yaml(
       'deploy/helm/' + operator_name,
       name=operator_name,
       set=[
-         'image.repository=docker.stackable.tech/sandbox/' + operator_name,
+         registry + '/' + operator_name,
       ],
    ),
    api_version = "^apiextensions\\.k8s\\.io/.*$",

--- a/template/Tiltfile
+++ b/template/Tiltfile
@@ -27,7 +27,7 @@ helm_crds, helm_non_crds = filter_yaml(
       'deploy/helm/' + operator_name,
       name=operator_name,
       set=[
-         registry + '/' + operator_name,
+         'image.repository=' + registry + '/' + operator_name,
       ],
    ),
    api_version = "^apiextensions\\.k8s\\.io/.*$",

--- a/template/default.nix
+++ b/template/default.nix
@@ -34,7 +34,7 @@ rec {
         fileRefVars = {
           PRODUCT_CONFIG = deploy/config-spec/properties.yaml;
         };
-      in lib.concatLists (lib.mapAttrsToList (env: path: lib.optional (lib.pathExists path) "${env}=${path}") fileRefVars);
+      in pkgs.lib.concatLists (pkgs.lib.mapAttrsToList (env: path: pkgs.lib.optional (pkgs.lib.pathExists path) "${env}=${path}") fileRefVars);
       Entrypoint = [ entrypoint ];
       Cmd = [ "run" ];
     };


### PR DESCRIPTION
Currently we hardcode the registry to be used for pushing docker images to stackables sandbox registry.
While this is fine for Stackable members, it won't work for external contributors. This PR adds the ability to create a config file for Tilt in which different registries can be specified that will then be picked up.

Since this file should only be used for user specific settings, it is also added to the .gitignore file to avoid it accidentally ending up in vc.