### PR TITLE
Added option to allow the user the option of not using crate2nix but the default Docker build process 

### DIFF
--- a/template/.gitignore.j2
+++ b/template/.gitignore.j2
@@ -13,3 +13,5 @@ Cargo.nix
 crate-hashes.json
 result
 image.tar
+
+tilt_options.json

--- a/template/Tiltfile
+++ b/template/Tiltfile
@@ -1,15 +1,28 @@
-default_registry("docker.stackable.tech/sandbox")
+# If tilt_options.json exists read it
+settings = read_json('tilt_options.json', default={})
+
+# Configure default registry either read from config file above, or with default value of "docker.stackable.tech/sandbox"
+registry = settings.get('default_registry', 'docker.stackable.tech/sandbox')
+default_registry(registry)
+
+# Configure which builder to use from config file, defaults to 'crate2nix'
+builder = settings.get('builder', 'crate2nix')
 
 meta = read_json('nix/meta.json')
 operator_name = meta['operator']['name']
 
-custom_build(
-    'docker.stackable.tech/sandbox/' + operator_name,
-    'nix shell -f . crate2nix -c crate2nix generate && nix-build . -A docker --argstr dockerName "${EXPECTED_REGISTRY}/' + operator_name + '" && ./result/load-image | docker load',
-    deps=['rust', 'Cargo.toml', 'Cargo.lock', 'default.nix', "nix", 'build.rs', 'vendor'],
-    # ignore=['result*', 'Cargo.nix', 'target', *.yaml],
-    outputs_image_ref_to='result/ref',
-)
+if builder == 'crate2nix':
+    custom_build(
+        registry + '/' + operator_name,
+        'nix shell -f . crate2nix -c crate2nix generate && nix-build . -A docker --argstr dockerName "${EXPECTED_REGISTRY}/' + operator_name + '" && ./result/load-image | docker load',
+        deps=['rust', 'Cargo.toml', 'Cargo.lock', 'default.nix', "nix", 'build.rs', 'vendor'],
+        # ignore=['result*', 'Cargo.nix', 'target', *.yaml],
+        outputs_image_ref_to='result/ref',
+    )
+else if builder == 'docker':
+    docker_build(registry + '/' + operator_name, '.', dockerfile='docker/Dockerfile')
+else:
+    fail('Unsupported builder specified: [' + builder + '] - currently supported builders are: [docker, crate2nix]')
 
 # Load the latest CRDs from Nix
 watch_file('result')
@@ -22,7 +35,7 @@ helm_crds, helm_non_crds = filter_yaml(
       'deploy/helm/' + operator_name,
       name=operator_name,
       set=[
-         'image.repository=docker.stackable.tech/sandbox/' + operator_name,
+         'image.repository=' + registry + '/' + operator_name,
       ],
    ),
    api_version = "^apiextensions\\.k8s\\.io/.*$",

--- a/template/default.nix
+++ b/template/default.nix
@@ -34,7 +34,7 @@ rec {
         fileRefVars = {
           PRODUCT_CONFIG = deploy/config-spec/properties.yaml;
         };
-      in lib.concatLists (lib.mapAttrsToList (env: path: lib.optional (lib.pathExists path) "${env}=${path}") fileRefVars);
+      in pkgs.lib.concatLists (pkgs.lib.mapAttrsToList (env: path: pkgs.lib.optional (pkgs.lib.pathExists path) "${env}=${path}") fileRefVars);
       Entrypoint = [ entrypoint ];
       Cmd = [ "run" ];
     };


### PR DESCRIPTION
Not sure if this is feasible to use with Tilt due to fairly long build times, might be necessary to pause deployment of the resources in Tilt and manually triggering as and when needed.