### PR TITLE
Cross-platform fix

### DIFF
--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -52,7 +52,8 @@ chart-clean:
 	rm -rf "deploy/helm/${OPERATOR_NAME}/crds"
 
 version:
-	yq eval -i ".version = \"${VERSION}\" | .appVersion = \"${VERSION}\"" /dev/stdin < "deploy/helm/${OPERATOR_NAME}/Chart.yaml"
+	cat "deploy/helm/${OPERATOR_NAME}/Chart.yaml" | yq ".version = \"${VERSION}\" | .appVersion = \"${VERSION}\"" > "deploy/helm/${OPERATOR_NAME}/Chart.yaml.new"
+	mv "deploy/helm/${OPERATOR_NAME}/Chart.yaml.new" "deploy/helm/${OPERATOR_NAME}/Chart.yaml"
 
 config:
 	if [ -d "deploy/config-spec/" ]; then\


### PR DESCRIPTION
This fixes that MacOS can't use dev/stdin to fetch input from. 

Instead we moved to cat into a new file then mv it to the original one