### PR TITLE
chore: Add chart regeneration as pre-commit hook

### DIFF
--- a/template/.pre-commit-config.yaml.j2
+++ b/template/.pre-commit-config.yaml.j2
@@ -34,11 +34,11 @@ repos:
     hooks:
       - id: flake8
 
-    - repo: local
-      hooks:
-        - id: regenerate-charts
-          name: regenerate-charts
-          language: system
-          entry: make regenerate-charts
-          stages: [commit, merge-commit, manual]
-          pass_filenames: false
+  - repo: local
+    hooks:
+      - id: regenerate-charts
+        name: regenerate-charts
+        language: system
+        entry: make regenerate-charts
+        stages: [commit, merge-commit, manual]
+        pass_filenames: false

--- a/template/.pre-commit-config.yaml.j2
+++ b/template/.pre-commit-config.yaml.j2
@@ -33,3 +33,12 @@ repos:
     rev: 4.0.1
     hooks:
       - id: flake8
+
+    - repo: local
+      hooks:
+        - id: regenerate-charts
+          name: regenerate-charts
+          language: system
+          entry: make regenerate-charts
+          stages: [commit, merge-commit, manual]
+          pass_filenames: false


### PR DESCRIPTION
This adds Helm chart regeneration when committing new code. This ensures that the chart is always up-to-date.