### PR TITLE
fix: Makefile indentation

### DIFF
--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -81,5 +81,6 @@ publish: build docker-publish helm-publish
 run-dev:
 	kubectl apply -f deploy/stackable-operators-ns.yaml
 	nix run -f. tilt -- up --port {[5430 + operator_index}] --namespace stackable-operators
+
 stop-dev:
-        nix run -f. tilt -- down
+	nix run -f. tilt -- down


### PR DESCRIPTION
The new target `stop-dev` was indented using spaces instead of tabs.