### PR TITLE
Push artifacts to harbor

### DIFF
--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -282,9 +282,13 @@ jobs:
       - tests_passed
       - select_helm_repo
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     env:
       NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
       HELM_REPO: ${{ needs.select_helm_repo.outputs.helm_repository }}
+      OCI_REGISTRY_PASSWORD: ${{ secrets.HARBOR_ROBOT_STACKABLE_GITHUB_ACTION_BUILD_SECRET }}
+      OCI_REGISTRY_USERNAME: "robot$stackable+github-action-build"
     if: needs.select_helm_repo.outputs.helm_repository != 'skip'
     outputs:
       IMAGE_TAG: ${{ steps.printtag.outputs.IMAGE_TAG }}
@@ -312,6 +316,8 @@ jobs:
         # Recreate charts and publish charts and docker image. The "-e" is needed as we want to override the
         # default value in the makefile if called from this action, but not otherwise (i.e. when called locally).
         # This is needed for the HELM_REPO variable.
+      - name: Set up Cosign
+        uses: sigstore/cosign-installer@v3.0.5
       - name: Publish Docker image and Helm chart
         run: make -e publish
         # Output the name of the published image to the Job output for later use

--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -50,7 +50,7 @@ docker-publish:
 	# push to Harbor
 	# we need to use "value" here to prevent the variable from being recursively expanded by make (username contains a dollar sign, since it's a Harbor bot)
 	docker login --username '${value OCI_REGISTRY_USERNAME}' --password '${OCI_REGISTRY_PASSWORD}' '${OCI_REGISTRY_HOSTNAME}'
-	DOCKER_OUTPUT=$$(docker push --all-tags '${OCI_REGISTRY_HOSTNAME}/${ORGANIZATION}/${OPERATOR_NAME}');\
+	DOCKER_OUTPUT=$$(docker push --all-tags '${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}');\
 	# Obtain the digest of the pushed image from the output of `docker push`, because signing by tag is deprecated and will be removed from cosign in the future\
 	REPO_DIGEST_OF_IMAGE=$$(echo "$$DOCKER_OUTPUT" | awk '/^${VERSION}: digest: sha256:[0-9a-f]{64} size: [0-9]+$$/ { print $$3 }');\
 	if [ -z "$$REPO_DIGEST_OF_IMAGE" ]; then\
@@ -59,7 +59,7 @@ docker-publish:
 	fi;\
 	# This generates a signature and publishes it to the registry, next to the image\
 	# Uses the keyless signing flow with Github Actions as identity provider\
-	cosign sign -y ${DOCKER_REPO}/${ORGANIZATION}/${OPERATOR_NAME}:@$$REPO_DIGEST_OF_IMAGE
+	cosign sign -y ${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}:@$$REPO_DIGEST_OF_IMAGE
 
 # TODO remove if not used/needed
 docker: docker-build docker-publish

--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -13,10 +13,13 @@ TAG    := $(shell git rev-parse --short HEAD)
 OPERATOR_NAME := {[ operator.name }]
 VERSION := $(shell cargo metadata --format-version 1 | jq -r '.packages[] | select(.name=="stackable-${OPERATOR_NAME}") | .version')
 
-DOCKER_REPO := docker.stackable.tech
 ORGANIZATION := stackable
+OCI_REGISTRY_HOSTNAME := broadminded-goldstine.container-registry.com
+OCI_REGISTRY_PROJECT_IMAGES := ${ORGANIZATION}
+OCI_REGISTRY_PROJECT_CHARTS := ${OCI_REGISTRY_PROJECT_IMAGES}
 # this will be overwritten by an environmental variable if called from the github action
 HELM_REPO := https://repo.stackable.tech/repository/helm-dev
+HELM_CHART_NAME := ${OPERATOR_NAME}
 HELM_CHART_ARTIFACT := target/helm/${OPERATOR_NAME}-${VERSION}.tgz
 
 SHELL=/usr/bin/env bash -euo pipefail
@@ -26,11 +29,18 @@ render-readme:
 
 ## Docker related targets
 docker-build:
-	docker build --force-rm --build-arg VERSION=${VERSION} -t "${DOCKER_REPO}/${ORGANIZATION}/${OPERATOR_NAME}:${VERSION}" -f docker/Dockerfile .
+	docker build --force-rm --build-arg VERSION=${VERSION} -t '${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}:${VERSION}' -f docker/Dockerfile .
 
 docker-publish:
-	echo "${NEXUS_PASSWORD}" | docker login --username github --password-stdin "${DOCKER_REPO}"
-	docker push --all-tags "${DOCKER_REPO}/${ORGANIZATION}/${OPERATOR_NAME}"
+	# we need to use "value" here to prevent the variable from being recursively expanded by make (username contains a dollar sign)
+	docker login --username '${value OCI_REGISTRY_USERNAME}' --password '${OCI_REGISTRY_PASSWORD}' '${OCI_REGISTRY_HOSTNAME}'
+	docker push --all-tags '${OCI_REGISTRY_HOSTNAME}/${ORGANIZATION}/${OPERATOR_NAME}'
+	REPO_ARTIFACT_BY_DIGEST=$$(docker inspect --format='{{range .RepoDigests}}{{ . }}{{end}}' '${OCI_REGISTRY_HOSTNAME}/${ORGANIZATION}/${OPERATOR_NAME}:${VERSION}' | grep -E '^${OCI_REGISTRY_HOSTNAME}/${ORGANIZATION}/${OPERATOR_NAME}@sha256:[0-9a-f]{64}$$' | head -n1);\
+	if [ -z "$$REPO_ARTIFACT_BY_DIGEST" ]; then\
+		echo 'Could not find repo digest for container image: ${OCI_REGISTRY_HOSTNAME}/${ORGANIZATION}/${OPERATOR_NAME}:${VERSION}';\
+		exit 1;\
+	fi;\
+	cosign sign -y $$REPO_ARTIFACT_BY_DIGEST
 
 # TODO remove if not used/needed
 docker: docker-build docker-publish
@@ -40,6 +50,14 @@ print-docker-tag:
 
 helm-publish:
 	curl --fail -u "github:${NEXUS_PASSWORD}" --upload-file "${HELM_CHART_ARTIFACT}" "${HELM_REPO}/"
+	# we need to use "value" here to prevent the variable from being recursively expanded by make (username contains a dollar sign)
+	helm registry login --username '${value OCI_REGISTRY_USERNAME}' --password '${OCI_REGISTRY_PASSWORD}' '${OCI_REGISTRY_HOSTNAME}'
+	REPO_ARTIFACT_BY_DIGEST=$$(helm push ${HELM_CHART_ARTIFACT} oci://${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_CHARTS} 2>&1 | awk '/^Digest: sha256:[0-9a-f]{64}$$/ { print $$2 }');\
+	if [ -z "$$REPO_ARTIFACT_BY_DIGEST" ]; then\
+		echo 'Could not find repo digest for helm chart: ${HELM_CHART_NAME}';\
+		exit 1;\
+	fi;\
+	cosign sign -y ${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_CHARTS}/${HELM_CHART_NAME}:@$$REPO_ARTIFACT_BY_DIGEST
 
 helm-package:
 	mkdir -p target/helm && helm package --destination target/helm deploy/helm/${OPERATOR_NAME}
@@ -70,7 +88,7 @@ chart-lint: compile-chart
 
 clean: chart-clean
 	cargo clean
-	docker rmi --force "${DOCKER_REPO}/${ORGANIZATION}/${OPERATOR_NAME}:${VERSION}"
+	docker rmi --force '${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}:${VERSION}'
 
 regenerate-charts: chart-clean compile-chart
 


### PR DESCRIPTION
Fixes https://github.com/stackabletech/issues/issues/381.
This PR integrates pushing our built artifacts (container images and Helm charts) to Harbor (and signing them). This is just for testing purposes, as Harbor is not really in use yet and the naming scheme of the artifacts location will likely change. The code in this PR pushes images to `oci.stackable.tech/stackable/images/` and Helm charts to `oci.stackable.tech/stackable/charts/`.

I generated the templating for airflow-operator and ran the build successfully:
https://github.com/stackabletech/airflow-operator/actions/runs/5784123312