### PR TITLE
Allow MPL-2.0 license

### DIFF
--- a/template/deny.toml
+++ b/template/deny.toml
@@ -30,6 +30,7 @@ allow = [
     "LicenseRef-ring",
     "LicenseRef-webpki",
     "MIT",
+    "MPL-2.0",
     "Unicode-DFS-2016",
     "Zlib"
 ]


### PR DESCRIPTION
As discussed in Slack with Lars
Neded for `webpki-roots` and `option-ext`