### PR TITLE
Normalize nix build

### DIFF
--- a/template/default.nix
+++ b/template/default.nix
@@ -10,6 +10,9 @@
       tonic-reflection = attrs: {
         buildInputs = [ pkgs.rustfmt ];
       };
+      csi-grpc = attrs: {
+        nativeBuildInputs = [ pkgs.protobuf ];
+      };
       stackable-secret-operator = attrs: {
         buildInputs = [ pkgs.protobuf pkgs.rustfmt ];
       };

--- a/template/default.nix
+++ b/template/default.nix
@@ -15,19 +15,15 @@
       };
       krb5-sys = attrs: {
         nativeBuildInputs = [ pkgs.pkg-config ];
-        buildInputs = {[% if operator.name == "secret-operator" -%}] [ pkgs.krb5 ] {[%- else -%}] [ (pkgs.enableDebugging pkgs.krb5) ] {[%- endif -%}];
+        buildInputs = [ pkgs.krb5 ];
         LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
         BINDGEN_EXTRA_CLANG_ARGS = "-I${pkgs.glibc.dev}/include -I${pkgs.clang.cc.lib}/lib/clang/${pkgs.lib.getVersion pkgs.clang.cc}/include";
       };
-      {[%- if operator.name == "secret-operator" %}]
-
       libgssapi-sys = attrs: {
         buildInputs = [ pkgs.krb5 ];
         LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
         BINDGEN_EXTRA_CLANG_ARGS = "-I${pkgs.glibc.dev}/include -I${pkgs.clang.cc.lib}/lib/clang/${pkgs.lib.getVersion pkgs.clang.cc}/include";
       };
-      {[%- endif %}]
-
     };
   }
 , meta ? pkgs.lib.importJSON ./nix/meta.json


### PR DESCRIPTION
Hoisted `csi-grpc` rules from listener-op, and removed the conditionals from #269.

This doesn't need to be rolled out immediately, the applicable repos have already been fixed.