### PR TITLE
Update crate2nix and set CARGO_MANIFEST_LINKS

### DIFF
--- a/template/default.nix
+++ b/template/default.nix
@@ -27,6 +27,11 @@
         LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
         BINDGEN_EXTRA_CLANG_ARGS = "-I${pkgs.glibc.dev}/include -I${pkgs.clang.cc.lib}/lib/clang/${pkgs.lib.getVersion pkgs.clang.cc}/include";
       };
+      # FIXME: Remove when https://github.com/NixOS/nixpkgs/pull/266787 is merged.
+      # See https://github.com/stackabletech/operator-templating/pull/289 for details.
+      ring = attrs: {
+        CARGO_MANIFEST_LINKS = "ring_core_0_17_5";
+      };
     };
   }
 , meta ? pkgs.lib.importJSON ./nix/meta.json

--- a/template/default.nix
+++ b/template/default.nix
@@ -30,7 +30,7 @@
       # FIXME: Remove when https://github.com/NixOS/nixpkgs/pull/266787 is merged.
       # See https://github.com/stackabletech/operator-templating/pull/289 for details.
       ring = attrs: {
-        CARGO_MANIFEST_LINKS = "ring_core_0_17_5";
+        CARGO_MANIFEST_LINKS = attrs.links;
       };
     };
   }

--- a/template/nix/sources.json
+++ b/template/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "kolloch",
         "repo": "crate2nix",
-        "rev": "8749f46953b46d44fd181b002399e4a20371f323",
-        "sha256": "13gn5zynbzih8lrhf2y486km7g0dhfiss5hh2m2mssn8r50k6jqx",
+        "rev": "a3fb25472c3796718b100a6e36f41088b0a0de14",
+        "sha256": "0g6zi7gzq9snpilrn3fkid5p9k9fdy4xcfn3q5c4kadrr9i3hbr8",
         "type": "tarball",
-        "url": "https://github.com/kolloch/crate2nix/archive/8749f46953b46d44fd181b002399e4a20371f323.tar.gz",
+        "url": "https://github.com/kolloch/crate2nix/archive/a3fb25472c3796718b100a6e36f41088b0a0de14.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {


### PR DESCRIPTION
Previously we were running into https://github.com/briansmith/ring/issues/1786.
We need to update to pull in https://github.com/nix-community/crate2nix/pull/314.
Also, https://github.com/NixOS/nixpkgs/pull/266787 is not merged yet, so we set the env var to the expected value manually.
Once https://github.com/NixOS/nixpkgs/pull/266787 is merged, we should remove the manual env var.