### PR TITLE
chore: Update nixpkgs and remove workaround

### DIFF
--- a/template/default.nix
+++ b/template/default.nix
@@ -20,12 +20,18 @@
         nativeBuildInputs = [ pkgs.pkg-config ];
         buildInputs = [ pkgs.krb5 ];
         LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
-        BINDGEN_EXTRA_CLANG_ARGS = "-I${pkgs.glibc.dev}/include -I${pkgs.clang.cc.lib}/lib/clang/${pkgs.lib.getVersion pkgs.clang.cc}/include";
+        # Clang's resource directory is located at ${pkgs.clang.cc.lib}/lib/clang/<version>.
+        # Starting with Clang 16, only the major version is used for the resource directory,
+        # whereas the full version was used in prior Clang versions (see
+        # https://github.com/llvm/llvm-project/commit/e1b88c8a09be25b86b13f98755a9bd744b4dbf14).
+        # The clang wrapper ${pkgs.clang} provides a symlink to the resource directory, which
+        # we use instead.
+        BINDGEN_EXTRA_CLANG_ARGS = "-I${pkgs.glibc.dev}/include -I${pkgs.clang}/resource-root/include";
       };
       libgssapi-sys = attrs: {
         buildInputs = [ pkgs.krb5 ];
         LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
-        BINDGEN_EXTRA_CLANG_ARGS = "-I${pkgs.glibc.dev}/include -I${pkgs.clang.cc.lib}/lib/clang/${pkgs.lib.getVersion pkgs.clang.cc}/include";
+        BINDGEN_EXTRA_CLANG_ARGS = "-I${pkgs.glibc.dev}/include -I${pkgs.clang}/resource-root/include";
       };
     };
   }

--- a/template/default.nix
+++ b/template/default.nix
@@ -27,11 +27,6 @@
         LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
         BINDGEN_EXTRA_CLANG_ARGS = "-I${pkgs.glibc.dev}/include -I${pkgs.clang.cc.lib}/lib/clang/${pkgs.lib.getVersion pkgs.clang.cc}/include";
       };
-      # FIXME: Remove when https://github.com/NixOS/nixpkgs/pull/266787 is merged.
-      # See https://github.com/stackabletech/operator-templating/pull/289 for details.
-      ring = attrs: {
-        CARGO_MANIFEST_LINKS = attrs.links;
-      };
     };
   }
 , meta ? pkgs.lib.importJSON ./nix/meta.json

--- a/template/nix/sources.json
+++ b/template/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "676fe5e01b9a41fa14aaa48d87685677664104b1",
-        "sha256": "0afm0dvqrjzdxhilhg0x9rbw8apfd5yg79f4qpdmdfzd8h68h72i",
+        "rev": "3f21a22b5aafefa1845dec6f4a378a8f53d8681c",
+        "sha256": "15y8k3hazg91kscbmn7dy6m0q6zvmhlvvhg97gcl5kw87y0svzxk",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/676fe5e01b9a41fa14aaa48d87685677664104b1.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/3f21a22b5aafefa1845dec6f4a378a8f53d8681c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
Follow-up of https://github.com/stackabletech/operator-templating/pull/289 as https://github.com/NixOS/nixpkgs/pull/266787 was merged