### PR TITLE
New Harbor project names

### DIFF
--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -296,10 +296,10 @@ jobs:
     env:
       NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
       HELM_REPO: ${{ needs.select_helm_repo.outputs.helm_repository }}
-      OCI_REGISTRY_STACKABLE_PASSWORD: ${{ secrets.HARBOR_ROBOT_STACKABLE_GITHUB_ACTION_BUILD_SECRET }}
-      OCI_REGISTRY_STACKABLE_USERNAME: "robot$stackable+github-action-build"
-      OCI_REGISTRY_STACKABLE_CHARTS_PASSWORD: ${{ secrets.HARBOR_ROBOT_STACKABLE_CHARTS_GITHUB_ACTION_BUILD_SECRET }}
-      OCI_REGISTRY_STACKABLE_CHARTS_USERNAME: "robot$stackable-charts+github-action-build"
+      OCI_REGISTRY_STACKABLE_PASSWORD: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
+      OCI_REGISTRY_STACKABLE_USERNAME: "robot$sdp+github-action-build"
+      OCI_REGISTRY_STACKABLE_CHARTS_PASSWORD: ${{ secrets.HARBOR_ROBOT_SDP_CHARTS_GITHUB_ACTION_BUILD_SECRET }}
+      OCI_REGISTRY_STACKABLE_CHARTS_USERNAME: "robot$sdp-charts+github-action-build"
     if: needs.select_helm_repo.outputs.helm_repository != 'skip'
     outputs:
       IMAGE_TAG: ${{ steps.printtag.outputs.IMAGE_TAG }}

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -296,10 +296,10 @@ jobs:
     env:
       NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
       HELM_REPO: ${{ needs.select_helm_repo.outputs.helm_repository }}
-      OCI_REGISTRY_STACKABLE_PASSWORD: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
-      OCI_REGISTRY_STACKABLE_USERNAME: "robot$sdp+github-action-build"
-      OCI_REGISTRY_STACKABLE_CHARTS_PASSWORD: ${{ secrets.HARBOR_ROBOT_SDP_CHARTS_GITHUB_ACTION_BUILD_SECRET }}
-      OCI_REGISTRY_STACKABLE_CHARTS_USERNAME: "robot$sdp-charts+github-action-build"
+      OCI_REGISTRY_SDP_PASSWORD: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
+      OCI_REGISTRY_SDP_USERNAME: "robot$sdp+github-action-build"
+      OCI_REGISTRY_SDP_CHARTS_PASSWORD: ${{ secrets.HARBOR_ROBOT_SDP_CHARTS_GITHUB_ACTION_BUILD_SECRET }}
+      OCI_REGISTRY_SDP_CHARTS_USERNAME: "robot$sdp-charts+github-action-build"
     if: needs.select_helm_repo.outputs.helm_repository != 'skip'
     outputs:
       IMAGE_TAG: ${{ steps.printtag.outputs.IMAGE_TAG }}

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -296,8 +296,10 @@ jobs:
     env:
       NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
       HELM_REPO: ${{ needs.select_helm_repo.outputs.helm_repository }}
-      OCI_REGISTRY_PASSWORD: ${{ secrets.HARBOR_ROBOT_STACKABLE_GITHUB_ACTION_BUILD_SECRET }}
-      OCI_REGISTRY_USERNAME: "robot$stackable+github-action-build"
+      OCI_REGISTRY_STACKABLE_PASSWORD: ${{ secrets.HARBOR_ROBOT_STACKABLE_GITHUB_ACTION_BUILD_SECRET }}
+      OCI_REGISTRY_STACKABLE_USERNAME: "robot$stackable+github-action-build"
+      OCI_REGISTRY_STACKABLE_CHARTS_PASSWORD: ${{ secrets.HARBOR_ROBOT_STACKABLE_CHARTS_GITHUB_ACTION_BUILD_SECRET }}
+      OCI_REGISTRY_STACKABLE_CHARTS_USERNAME: "robot$stackable-charts+github-action-build"
     if: needs.select_helm_repo.outputs.helm_repository != 'skip'
     outputs:
       IMAGE_TAG: ${{ steps.printtag.outputs.IMAGE_TAG }}

--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -16,9 +16,9 @@ VERSION := $(shell cargo metadata --format-version 1 | jq -r '.packages[] | sele
 DOCKER_REPO := docker.stackable.tech
 ORGANIZATION := stackable
 OCI_REGISTRY_HOSTNAME := oci.stackable.tech
-OCI_REGISTRY_PROJECT_IMAGES := ${ORGANIZATION}/images
-OCI_REGISTRY_PROJECT_CHARTS := ${ORGANIZATION}/charts
-# this will be overwritten by an environmental variable if called from the github action
+OCI_REGISTRY_PROJECT_IMAGES := ${ORGANIZATION}
+OCI_REGISTRY_PROJECT_CHARTS := ${ORGANIZATION}-charts
+# This will be overwritten by an environmental variable if called from the github action
 HELM_REPO := https://repo.stackable.tech/repository/helm-dev
 HELM_CHART_NAME := ${OPERATOR_NAME}
 HELM_CHART_ARTIFACT := target/helm/${OPERATOR_NAME}-${VERSION}.tgz
@@ -34,7 +34,7 @@ docker-build:
 	docker tag "${DOCKER_REPO}/${ORGANIZATION}/${OPERATOR_NAME}:${VERSION}" "${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}:${VERSION}"
 
 docker-publish:
-	# push to Nexus
+	# Push to Nexus
 	echo "${NEXUS_PASSWORD}" | docker login --username github --password-stdin "${DOCKER_REPO}"
 	DOCKER_OUTPUT=$$(docker push --all-tags "${DOCKER_REPO}/${ORGANIZATION}/${OPERATOR_NAME}");\
 	# Obtain the digest of the pushed image from the output of `docker push`, because signing by tag is deprecated and will be removed from cosign in the future\
@@ -47,9 +47,9 @@ docker-publish:
 	# Uses the keyless signing flow with Github Actions as identity provider\
 	cosign sign -y ${DOCKER_REPO}/${ORGANIZATION}/${OPERATOR_NAME}:@$$REPO_DIGEST_OF_IMAGE
 
-	# push to Harbor
-	# we need to use "value" here to prevent the variable from being recursively expanded by make (username contains a dollar sign, since it's a Harbor bot)
-	docker login --username '${value OCI_REGISTRY_USERNAME}' --password '${OCI_REGISTRY_PASSWORD}' '${OCI_REGISTRY_HOSTNAME}'
+	# Push to Harbor
+	# We need to use "value" here to prevent the variable from being recursively expanded by make (username contains a dollar sign, since it's a Harbor bot)
+	docker login --username '${value OCI_REGISTRY_STACKABLE_USERNAME}' --password '${OCI_REGISTRY_STACKABLE_PASSWORD}' '${OCI_REGISTRY_HOSTNAME}'
 	DOCKER_OUTPUT=$$(docker push --all-tags '${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}');\
 	# Obtain the digest of the pushed image from the output of `docker push`, because signing by tag is deprecated and will be removed from cosign in the future\
 	REPO_DIGEST_OF_IMAGE=$$(echo "$$DOCKER_OUTPUT" | awk '/^${VERSION}: digest: sha256:[0-9a-f]{64} size: [0-9]+$$/ { print $$3 }');\
@@ -68,12 +68,12 @@ print-docker-tag:
 	@echo "${DOCKER_REPO}/${ORGANIZATION}/${OPERATOR_NAME}:${VERSION}"
 
 helm-publish:
-	# push to Nexus
+	# Push to Nexus
 	curl --fail -u "github:${NEXUS_PASSWORD}" --upload-file "${HELM_CHART_ARTIFACT}" "${HELM_REPO}/"
 
-	# push to Harbor
-	# we need to use "value" here to prevent the variable from being recursively expanded by make (username contains a dollar sign, since it's a Harbor bot)
-	helm registry login --username '${value OCI_REGISTRY_USERNAME}' --password '${OCI_REGISTRY_PASSWORD}' '${OCI_REGISTRY_HOSTNAME}'
+	# Push to Harbor
+	# We need to use "value" here to prevent the variable from being recursively expanded by make (username contains a dollar sign, since it's a Harbor bot)
+	helm registry login --username '${value OCI_REGISTRY_STACKABLE_CHARTS_USERNAME}' --password '${OCI_REGISTRY_STACKABLE_CHARTS_PASSWORD}' '${OCI_REGISTRY_HOSTNAME}'
 	# Obtain the digest of the pushed artifact from the output of `helm push`, because signing by tag is deprecated and will be removed from cosign in the future\
 	HELM_OUTPUT=$$(helm push '${HELM_CHART_ARTIFACT}' 'oci://${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_CHARTS}' 2>&1);\
 	REPO_DIGEST_OF_ARTIFACT=$$(echo "$$HELM_OUTPUT" | awk '/^Digest: sha256:[0-9a-f]{64}$$/ { print $$2 }');\
@@ -81,6 +81,8 @@ helm-publish:
 		echo 'Could not find repo digest for helm chart: ${HELM_CHART_NAME}';\
 		exit 1;\
 	fi;\
+	# Login to Harbor, needed for cosign to be able to push the signature for the Helm chart\
+	docker login --username '${value OCI_REGISTRY_STACKABLE_CHARTS_USERNAME}' --password '${OCI_REGISTRY_STACKABLE_CHARTS_PASSWORD}' '${OCI_REGISTRY_HOSTNAME}';\
 	# This generates a signature and publishes it to the registry, next to the chart artifact\
 	# Uses the keyless signing flow with Github Actions as identity provider\
 	cosign sign -y ${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_CHARTS}/${HELM_CHART_NAME}:@$$REPO_DIGEST_OF_ARTIFACT

--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -16,8 +16,8 @@ VERSION := $(shell cargo metadata --format-version 1 | jq -r '.packages[] | sele
 DOCKER_REPO := docker.stackable.tech
 ORGANIZATION := stackable
 OCI_REGISTRY_HOSTNAME := oci.stackable.tech
-OCI_REGISTRY_PROJECT_IMAGES := ${ORGANIZATION}
-OCI_REGISTRY_PROJECT_CHARTS := ${ORGANIZATION}-charts
+OCI_REGISTRY_PROJECT_IMAGES := sdp
+OCI_REGISTRY_PROJECT_CHARTS := sdp-charts
 # This will be overwritten by an environmental variable if called from the github action
 HELM_REPO := https://repo.stackable.tech/repository/helm-dev
 HELM_CHART_NAME := ${OPERATOR_NAME}
@@ -54,7 +54,7 @@ docker-publish:
 	# Obtain the digest of the pushed image from the output of `docker push`, because signing by tag is deprecated and will be removed from cosign in the future\
 	REPO_DIGEST_OF_IMAGE=$$(echo "$$DOCKER_OUTPUT" | awk '/^${VERSION}: digest: sha256:[0-9a-f]{64} size: [0-9]+$$/ { print $$3 }');\
 	if [ -z "$$REPO_DIGEST_OF_IMAGE" ]; then\
-		echo 'Could not find repo digest for container image: ${DOCKER_REPO}/${ORGANIZATION}/${OPERATOR_NAME}:${VERSION}';\
+		echo 'Could not find repo digest for container image: ${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}:${VERSION}';\
 		exit 1;\
 	fi;\
 	# This generates a signature and publishes it to the registry, next to the image\

--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -49,7 +49,7 @@ docker-publish:
 
 	# Push to Harbor
 	# We need to use "value" here to prevent the variable from being recursively expanded by make (username contains a dollar sign, since it's a Harbor bot)
-	docker login --username '${value OCI_REGISTRY_STACKABLE_USERNAME}' --password '${OCI_REGISTRY_STACKABLE_PASSWORD}' '${OCI_REGISTRY_HOSTNAME}'
+	docker login --username '${value OCI_REGISTRY_SDP_USERNAME}' --password '${OCI_REGISTRY_SDP_PASSWORD}' '${OCI_REGISTRY_HOSTNAME}'
 	DOCKER_OUTPUT=$$(docker push --all-tags '${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}');\
 	# Obtain the digest of the pushed image from the output of `docker push`, because signing by tag is deprecated and will be removed from cosign in the future\
 	REPO_DIGEST_OF_IMAGE=$$(echo "$$DOCKER_OUTPUT" | awk '/^${VERSION}: digest: sha256:[0-9a-f]{64} size: [0-9]+$$/ { print $$3 }');\
@@ -73,7 +73,7 @@ helm-publish:
 
 	# Push to Harbor
 	# We need to use "value" here to prevent the variable from being recursively expanded by make (username contains a dollar sign, since it's a Harbor bot)
-	helm registry login --username '${value OCI_REGISTRY_STACKABLE_CHARTS_USERNAME}' --password '${OCI_REGISTRY_STACKABLE_CHARTS_PASSWORD}' '${OCI_REGISTRY_HOSTNAME}'
+	helm registry login --username '${value OCI_REGISTRY_SDP_CHARTS_USERNAME}' --password '${OCI_REGISTRY_SDP_CHARTS_PASSWORD}' '${OCI_REGISTRY_HOSTNAME}'
 	# Obtain the digest of the pushed artifact from the output of `helm push`, because signing by tag is deprecated and will be removed from cosign in the future\
 	HELM_OUTPUT=$$(helm push '${HELM_CHART_ARTIFACT}' 'oci://${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_CHARTS}' 2>&1);\
 	REPO_DIGEST_OF_ARTIFACT=$$(echo "$$HELM_OUTPUT" | awk '/^Digest: sha256:[0-9a-f]{64}$$/ { print $$2 }');\
@@ -82,7 +82,7 @@ helm-publish:
 		exit 1;\
 	fi;\
 	# Login to Harbor, needed for cosign to be able to push the signature for the Helm chart\
-	docker login --username '${value OCI_REGISTRY_STACKABLE_CHARTS_USERNAME}' --password '${OCI_REGISTRY_STACKABLE_CHARTS_PASSWORD}' '${OCI_REGISTRY_HOSTNAME}';\
+	docker login --username '${value OCI_REGISTRY_SDP_CHARTS_USERNAME}' --password '${OCI_REGISTRY_SDP_CHARTS_PASSWORD}' '${OCI_REGISTRY_HOSTNAME}';\
 	# This generates a signature and publishes it to the registry, next to the chart artifact\
 	# Uses the keyless signing flow with Github Actions as identity provider\
 	cosign sign -y ${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_CHARTS}/${HELM_CHART_NAME}:@$$REPO_DIGEST_OF_ARTIFACT


### PR DESCRIPTION
Needed for https://github.com/stackabletech/infrastructure/issues/138

Mainly:
Images are not stored in "stackable/images" anymore, but directly in "stackable".
Helm charts are not stored in "stackable/charts" anymore, but in "stackable-charts".
This removes slashes from the Harbor repository names and thus provides compatibility with other registries like Dockerhub and Quay.
Since Helm charts are stored in another Harbor project now ("stackable-charts"), a new Robot account for that project was needed ("robot$stackable-charts+github-action-build"). I decided not to create one Robot account with general permissions in Harbor, but instead single Robot accounts for each project (currently, one for "stackable" and one for "stackable-charts").

Also:
Capitalized the first letters of some comments.


I generated the templating for the airflow-operator, here's the successful run of the Github Action:
https://github.com/stackabletech/airflow-operator/actions/runs/7103279068