### PR TITLE
Revert "Templating changes from the opa-operator user-info-fetcher work (#294)

### DIFF
--- a/template/Tiltfile
+++ b/template/Tiltfile
@@ -22,8 +22,6 @@ watch_file('result')
 if os.path.exists('result'):
    k8s_yaml('result/crds.yaml')
 
-k8s_kind('Deployment', image_json_path='{.spec.template.metadata.annotations.internal\\.stackable\\.tech/image}')
-
 # Exclude stale CRDs from Helm chart, and apply the rest
 helm_crds, helm_non_crds = filter_yaml(
    helm(
@@ -38,8 +36,3 @@ helm_crds, helm_non_crds = filter_yaml(
    kind = "^CustomResourceDefinition$",
 )
 k8s_yaml(helm_non_crds)
-
-{[% if operator.product_string in ['opa'] %}]
-# k8s_yaml('docs/modules/opa/examples/getting_started/opa.yaml')
-# k8s_resource(new_name='simple-opa', objects=['simple-opa:OpaCluster'], extra_pod_selectors=[{'app.kubernetes.io/name': 'opa'}], port_forwards=['8081:8081', '9476:9476'])
-{[% endif %}]

--- a/template/deploy/helm/[[operator]]/templates/deployment.yaml.j2
+++ b/template/deploy/helm/[[operator]]/templates/deployment.yaml.j2
@@ -15,12 +15,11 @@ spec:
       {{- include "operator.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
       annotations:
-        internal.stackable.tech/image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-        {{- with .Values.podAnnotations }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
+      {{- end }}
       labels:
         {{- include "operator.selectorLabels" . | nindent 8 }}
     spec:
@@ -42,17 +41,13 @@ spec:
           volumeMounts:
             - mountPath: /etc/stackable/{{ include "operator.appname" . }}/config-spec
               name: config-spec
-          env:
-            - name: OPERATOR_IMAGE
-              # Tilt can use annotations as image paths, but not env variables
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.annotations['internal.stackable.tech/image']
 {[% if operator.product_string in ['kafka'] %}]
+          env:
             - name: KAFKA_BROKER_CLUSTERROLE
               value: {{ include "operator.fullname" . }}-kafka-broker-clusterrole
 {[% endif %}]
 {[% if operator.product_string in ['opa'] %}]
+          env:
             - name: OPA_BUNDLE_BUILDER_CLUSTERROLE
               value: {{ include "operator.fullname" . }}-opa-bundle-builder-clusterrole
 {[% endif %}]


### PR DESCRIPTION
This reverts commit 1876cb9f538dbe9de070da49082902c2010bd7c3.

It contained templating errors
- Tiltfile had templating, but was not a j2 file.
- The changes are no longer needed for opa-operator, and not yet needed by anything else.