### PR TITLE
chore: Update default rust toolchain to 1.75

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -82,7 +82,7 @@ repositories:
 # IMPORTANT
 # If you change the Rust toolchain version here, make sure to also change
 # Docker-images/ubi8-rust-builder/Dockerfile
-rust_version: 1.74.0
+rust_version: 1.75.0
 
 # Anything specified in the retired_files variable will be deleted.
 # This is uncommented as I had issues with everything being deleted when this was just present as an empty key.

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -21,6 +21,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: '0'
   CARGO_PROFILE_DEV_DEBUG: '0'
+  RUST_TOOLCHAIN_VERSION: "{[ rust_version }]"
   RUSTFLAGS: "-D warnings"
   RUSTDOCFLAGS: "-D warnings"
   RUST_LOG: "info"
@@ -44,7 +45,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@{[ rust_version }]
+      - uses: dtolnay/rust-toolchain@${{ env.RUST_TOOLCHAIN_VERSION }}
       - uses: Swatinem/rust-cache@3cf7f8cc28d1b4e7d01e3783be10a97d55d483c8 # v2.7.1
         with:
           key: udeps
@@ -122,7 +123,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@{[ rust_version }]
+      - uses: dtolnay/rust-toolchain@${{ env.RUST_TOOLCHAIN_VERSION }}
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
@@ -139,7 +140,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@{[ rust_version }]
+      - uses: dtolnay/rust-toolchain@${{ env.RUST_TOOLCHAIN_VERSION }}
         with:
           components: clippy
       - uses: Swatinem/rust-cache@3cf7f8cc28d1b4e7d01e3783be10a97d55d483c8 # v2.7.1
@@ -174,7 +175,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@{[ rust_version }]
+      - uses: dtolnay/rust-toolchain@${{ env.RUST_TOOLCHAIN_VERSION }}
         with:
           components: rustfmt
       - uses: Swatinem/rust-cache@3cf7f8cc28d1b4e7d01e3783be10a97d55d483c8 # v2.7.1
@@ -195,7 +196,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@{[ rust_version }]
+      - uses: dtolnay/rust-toolchain@${{ env.RUST_TOOLCHAIN_VERSION }}
       - uses: Swatinem/rust-cache@3cf7f8cc28d1b4e7d01e3783be10a97d55d483c8 # v2.7.1
         with:
           key: test
@@ -258,7 +259,7 @@ jobs:
         with:
           version: v3.13.3
       - name: Set up cargo
-        uses: dtolnay/rust-toolchain@{[ rust_version }]
+        uses: dtolnay/rust-toolchain@${{ env.RUST_TOOLCHAIN_VERSION }}
       - uses: Swatinem/rust-cache@3cf7f8cc28d1b4e7d01e3783be10a97d55d483c8 # v2.7.1
         with:
           key: charts
@@ -318,7 +319,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@{[ rust_version }]
+      - uses: dtolnay/rust-toolchain@${{ env.RUST_TOOLCHAIN_VERSION }}
         with:
           components: rustfmt
         # This step checks if the current run was triggered by a push to a pr (or a pr being created).

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -21,7 +21,6 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: '0'
   CARGO_PROFILE_DEV_DEBUG: '0'
-  RUST_TOOLCHAIN_VERSION: "{[ rust_version }]"
   RUSTFLAGS: "-D warnings"
   RUSTDOCFLAGS: "-D warnings"
   RUST_LOG: "info"
@@ -45,7 +44,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@${{ env.RUST_TOOLCHAIN_VERSION }}
+      - uses: dtolnay/rust-toolchain@{[ rust_version }]
       - uses: Swatinem/rust-cache@3cf7f8cc28d1b4e7d01e3783be10a97d55d483c8 # v2.7.1
         with:
           key: udeps
@@ -123,7 +122,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@${{ env.RUST_TOOLCHAIN_VERSION }}
+      - uses: dtolnay/rust-toolchain@{[ rust_version }]
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
@@ -140,7 +139,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@${{ env.RUST_TOOLCHAIN_VERSION }}
+      - uses: dtolnay/rust-toolchain@{[ rust_version }]
         with:
           components: clippy
       - uses: Swatinem/rust-cache@3cf7f8cc28d1b4e7d01e3783be10a97d55d483c8 # v2.7.1
@@ -175,7 +174,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@${{ env.RUST_TOOLCHAIN_VERSION }}
+      - uses: dtolnay/rust-toolchain@{[ rust_version }]
         with:
           components: rustfmt
       - uses: Swatinem/rust-cache@3cf7f8cc28d1b4e7d01e3783be10a97d55d483c8 # v2.7.1
@@ -196,7 +195,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@${{ env.RUST_TOOLCHAIN_VERSION }}
+      - uses: dtolnay/rust-toolchain@{[ rust_version }]
       - uses: Swatinem/rust-cache@3cf7f8cc28d1b4e7d01e3783be10a97d55d483c8 # v2.7.1
         with:
           key: test
@@ -259,7 +258,7 @@ jobs:
         with:
           version: v3.13.3
       - name: Set up cargo
-        uses: dtolnay/rust-toolchain@${{ env.RUST_TOOLCHAIN_VERSION }}
+        uses: dtolnay/rust-toolchain@{[ rust_version }]
       - uses: Swatinem/rust-cache@3cf7f8cc28d1b4e7d01e3783be10a97d55d483c8 # v2.7.1
         with:
           key: charts
@@ -319,7 +318,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@${{ env.RUST_TOOLCHAIN_VERSION }}
+      - uses: dtolnay/rust-toolchain@{[ rust_version }]
         with:
           components: rustfmt
         # This step checks if the current run was triggered by a push to a pr (or a pr being created).

--- a/template/nix/sources.json
+++ b/template/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3f21a22b5aafefa1845dec6f4a378a8f53d8681c",
-        "sha256": "15y8k3hazg91kscbmn7dy6m0q6zvmhlvvhg97gcl5kw87y0svzxk",
+        "rev": "5ad9903c16126a7d949101687af0aa589b1d7d3d",
+        "sha256": "1i0nvgzzadbl29hzs5n4qbc0nnw69nh79b0kq3g7zi1926rczlqn",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/3f21a22b5aafefa1845dec6f4a378a8f53d8681c.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5ad9903c16126a7d949101687af0aa589b1d7d3d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
Upgrade the default rust toolchain version to 1.75

Here is a test run against airflow-operator:

~~~patch
diff --git a/nix/sources.json b/nix/sources.json
index 92a5322..ca7ce78 100644
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3f21a22b5aafefa1845dec6f4a378a8f53d8681c",
-        "sha256": "15y8k3hazg91kscbmn7dy6m0q6zvmhlvvhg97gcl5kw87y0svzxk",
+        "rev": "5ad9903c16126a7d949101687af0aa589b1d7d3d",
+        "sha256": "1i0nvgzzadbl29hzs5n4qbc0nnw69nh79b0kq3g7zi1926rczlqn",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/3f21a22b5aafefa1845dec6f4a378a8f53d8681c.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5ad9903c16126a7d949101687af0aa589b1d7d3d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }
diff --git a/rust-toolchain.toml b/rust-toolchain.toml
index 639f4f1..7897a24 100644
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.74.0"
+channel = "1.75.0"

~~~