### PR TITLE
Publish SBOMs

### DIFF
--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -335,7 +335,10 @@ jobs:
         # Recreate charts and publish charts and docker image. The "-e" is needed as we want to override the
         # default value in the makefile if called from this action, but not otherwise (i.e. when called locally).
         # This is needed for the HELM_REPO variable.
-      - uses: sigstore/cosign-installer@9614fae9e5c5eddabb09f90a270fcb487c9f7149 # tag=v3.3.0
+      - name: Install cosign
+        uses: sigstore/cosign-installer@9614fae9e5c5eddabb09f90a270fcb487c9f7149 # tag=v3.3.0
+      - name: Install syft
+        uses: anchore/sbom-action/download-syft@v0.15.5
       - name: Publish Docker image and Helm chart
         run: make -e publish
         # Output the name of the published image to the Job output for later use

--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -45,7 +45,7 @@ docker-publish:
 	fi;\
 	# This generates a signature and publishes it to the registry, next to the image\
 	# Uses the keyless signing flow with Github Actions as identity provider\
-	cosign sign -y ${DOCKER_REPO}/${ORGANIZATION}/${OPERATOR_NAME}:@$$REPO_DIGEST_OF_IMAGE
+	cosign sign -y ${DOCKER_REPO}/${ORGANIZATION}/${OPERATOR_NAME}@$$REPO_DIGEST_OF_IMAGE
 
 	# Push to Harbor
 	# We need to use "value" here to prevent the variable from being recursively expanded by make (username contains a dollar sign, since it's a Harbor bot)
@@ -59,7 +59,18 @@ docker-publish:
 	fi;\
 	# This generates a signature and publishes it to the registry, next to the image\
 	# Uses the keyless signing flow with Github Actions as identity provider\
-	cosign sign -y ${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}:@$$REPO_DIGEST_OF_IMAGE
+	cosign sign -y ${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}@$$REPO_DIGEST_OF_IMAGE;\
+	# Generate the SBOM for the operator, this leverages the already generated SBOM\
+	syft scan -o cyclonedx-json --exclude "/usr/local/bin/stackable-${OPERATOR_NAME}" --scope all-layers --source-name "${OPERATOR_NAME}" --source-version "${VERSION}" ${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}@$$REPO_DIGEST_OF_IMAGE > sbom.json;\
+	# Determine the PURL for the container image\
+	PURL="pkg:docker/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}@$$REPO_DIGEST_OF_IMAGE?repository_url=${OCI_REGISTRY_HOSTNAME}";\
+	# Get metadata from the image\
+	IMAGE_DESCRIPTION=$$(docker inspect --format='{{.Config.Labels.description}}' ${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}:${VERSION});\
+	IMAGE_NAME=$$(docker inspect --format='{{.Config.Labels.name}}' ${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}:${VERSION});\
+	# Merge the SBOM with the metadata for the operator\
+	jq -s '{"metadata":{"component":{"description":"'"$$IMAGE_NAME. $$IMAGE_DESCRIPTION"'","supplier":{"name":"Stackable GmbH","url":"https://stackable.tech/"},"author":"Stackable GmbH","purl":"'"$$PURL"'","publisher":"Stackable GmbH"}}} * .[0]' sbom.json > sbom.merged.json;\
+	# Attest the SBOM to the image\
+	cosign attest -y --predicate sbom.merged.json --type cyclonedx ${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}@$$REPO_DIGEST_OF_IMAGE
 
 # TODO remove if not used/needed
 docker: docker-build docker-publish
@@ -85,7 +96,7 @@ helm-publish:
 	docker login --username '${value OCI_REGISTRY_SDP_CHARTS_USERNAME}' --password '${OCI_REGISTRY_SDP_CHARTS_PASSWORD}' '${OCI_REGISTRY_HOSTNAME}';\
 	# This generates a signature and publishes it to the registry, next to the chart artifact\
 	# Uses the keyless signing flow with Github Actions as identity provider\
-	cosign sign -y ${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_CHARTS}/${HELM_CHART_NAME}:@$$REPO_DIGEST_OF_ARTIFACT
+	cosign sign -y ${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_CHARTS}/${HELM_CHART_NAME}@$$REPO_DIGEST_OF_ARTIFACT
 
 helm-package:
 	mkdir -p target/helm && helm package --destination target/helm deploy/helm/${OPERATOR_NAME}


### PR DESCRIPTION
Fixes https://github.com/stackabletech/issues/issues/398.

Successful test run with airflow-operator: https://github.com/stackabletech/airflow-operator/actions/runs/7652323720/job/20851912198

The verified SBOM for the airflow-operator can be fetched with:
```
cosign verify-attestation --type cyclonedx --certificate-identity-regexp '^https://github.com/stackabletech/.+/.github/workflows/.+@.+' --certificate-oidc-issuer https://token.actions.githubusercontent.com oci.stackable.tech/sdp/airflow-operator:0.0.0-dev | jq '.payload' -r | base64 -d | jq '.predicate' -r > verified_sbom.json
```

Notes and possible next steps:
 - I also removed an incorrect colon from the image references. Before, it was `${DOCKER_REPO}/${ORGANIZATION}/${OPERATOR_NAME}:@$$REPO_DIGEST_OF_IMAGE` which results in something like `oci.stackable.tech/sdp/airflow-operator:@sha256:b2707e4a282844d314aa4ee261b4680c91c0c5f484ed6d235282d7c4ff10bda2`, which is an invalid reference (but cosign ignored it and treated it correctly). Now it's `...airflow-operator@sha256:b27...` instead of `...airflow-operator:@sha256:b27...` (first colon removed).
 - I handcraft PURLs for the operator images in the `Makefile`. They look like this: `pkg:docker/sdp/airflow-operator@sha256:50c2df6011949ded5e17cf1c85facf568ffdcca679664feb540dd300ea7c07f5?repository_url=oci.stackable.tech`. I verified that one using [packageurl.rs](https://github.com/package-url/packageurl.rs):
```
PackageUrl {
    ty: "docker",
    namespace: Some(
        "sdp",
    ),
    name: "airflow-operator",
    version: Some(
        "sha256:50c2df6011949ded5e17cf1c85facf568ffdcca679664feb540dd300ea7c07f5",
    ),
    qualifiers: {
        "repository_url": "oci.stackable.tech",
    },
    subpath: None,
}
```
 - Syft adds all the labels from the container image to the SBOM under `.metadata.properties`. This includes a description of the UBI minimal image, which we could remove from the image labels during the build process.
 - Out operator images contain Python (`/usr/libexec/platform-python3.6`), we could check whether it's needed and where it comes from.
 - We need to document to our customers how to get and verify the SBOMs. Customers can enforce the presence of a valid SBOM before starting a container via tools like Kyverno. Since SBOMs are published in Harbor this will first be relevant once we pull our images from Harbor by default.
 - When I ran Syft version 0.101.1 on my Macbook, it reported all the crates for airflow-operator twice: once with our generated SBOM as source (the one generated by `cargo cyclonedx`), once with the operator binary as source. This did not happen on Linux (even though it was the same version), there it only reported the crates with the SBOM as source (which is what we want). I haven't debugged this further and just passed the `--exclude "/usr/local/bin/stackable-${OPERATOR_NAME}"` flag to Syft to make sure it does not try to analyze the binary, that way it produced the correct output for me on MacOS and Linux.