### PR TITLE
Fix SBOM supplier metadata: "url" has to be an array of strings

### DIFF
--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -68,7 +68,7 @@ docker-publish:
 	IMAGE_DESCRIPTION=$$(docker inspect --format='{{.Config.Labels.description}}' "${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}:${VERSION}");\
 	IMAGE_NAME=$$(docker inspect --format='{{.Config.Labels.name}}' "${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}:${VERSION}");\
 	# Merge the SBOM with the metadata for the operator\
-	jq -s '{"metadata":{"component":{"description":"'"$$IMAGE_NAME. $$IMAGE_DESCRIPTION"'","supplier":{"name":"Stackable GmbH","url":"https://stackable.tech/"},"author":"Stackable GmbH","purl":"'"$$PURL"'","publisher":"Stackable GmbH"}}} * .[0]' sbom.json > sbom.merged.json;\
+	jq -s '{"metadata":{"component":{"description":"'"$$IMAGE_NAME. $$IMAGE_DESCRIPTION"'","supplier":{"name":"Stackable GmbH","url":["https://stackable.tech/"]},"author":"Stackable GmbH","purl":"'"$$PURL"'","publisher":"Stackable GmbH"}}} * .[0]' sbom.json > sbom.merged.json;\
 	# Attest the SBOM to the image\
 	cosign attest -y --predicate sbom.merged.json --type cyclonedx "${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}@$$REPO_DIGEST_OF_IMAGE"
 


### PR DESCRIPTION
Tiny fix: I just saw that, according to the CycloneDX 1.5 spec, the "url" attribute of "supplier" has to be an array instead of a string. Rest of the metadata is correct, I ran the SBOM through a validator.

I tested building the SBOM in this workflow: https://github.com/stackabletech/airflow-operator/actions/runs/7712824289
And validated it using https://github.com/CycloneDX/sbom-utility:
```
[INFO] Matching BOM schema (for validation): schema/cyclonedx/1.5/bom-1.5.schema.json
[INFO] Loading schema `schema/cyclonedx/1.5/bom-1.5.schema.json`...
[INFO] Schema `schema/cyclonedx/1.5/bom-1.5.schema.json` loaded.
[INFO] Validating `airflow-op-sbom.json`...
[INFO] BOM valid against JSON schema: `true`
```