### PR TITLE
Github Linguist ignore generated nix files

### DIFF
--- a/template/.gitattributes
+++ b/template/.gitattributes
@@ -1,0 +1,3 @@
+nix/** linguist-generated
+Cargo.nix linguist-generated
+crate-hashes.json linguist-generated

--- a/template/.gitignore.j2
+++ b/template/.gitignore.j2
@@ -9,8 +9,6 @@ target/
 
 *.tgz
 
-Cargo.nix
-crate-hashes.json
 result
 image.tar
 


### PR DESCRIPTION
This change will stop generated nix files in the templated operators from being included in the stats, and diffs will be hidden by default (long files are anyway). More information in the [linguist docs](https://github.com/github-linguist/linguist/blob/master/docs/overrides.md).

Semi-relevant discussion: https://github.com/stackabletech/secret-operator/pull/344#discussion_r1492148641.
