### PR TITLE
chore: Add shell.nix for all operators

### DIFF
--- a/playbook/update_repo.yaml
+++ b/playbook/update_repo.yaml
@@ -94,6 +94,11 @@
         argv: [make, regenerate-charts]
         chdir: "{{ work_dir }}/{{ operator.name }}"
 
+    - name: "Operator [{{ operator.name }}] regenerate crate2nix"
+      command:
+        argv: [make, regenerate-nix]
+        chdir: "{{ work_dir }}/{{ operator.name }}"
+
     - name: "Operator [{{ operator.name }}] re-render README"
       command:
         argv: [make, render-readme]

--- a/template/.github/workflows/pr_reviewdog.yaml
+++ b/template/.github/workflows/pr_reviewdog.yaml
@@ -75,6 +75,9 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           locale: "US"
+          # Ignore spellchecking generated files
+          exclude: |
+            ./Cargo.nix
 
   languagetool:
     runs-on: ubuntu-latest

--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -132,7 +132,10 @@ clean: chart-clean
 
 regenerate-charts: chart-clean compile-chart
 
-build: regenerate-charts helm-package docker-build
+regenerate-nix:
+	nix run -f . regenerateNixLockfiles
+
+build: regenerate-charts regenerate-nix helm-package docker-build
 
 publish: build docker-publish helm-publish
 

--- a/template/Tiltfile
+++ b/template/Tiltfile
@@ -10,7 +10,7 @@ operator_name = meta['operator']['name']
 
 custom_build(
     registry + '/' + operator_name,
-    'nix shell -f . crate2nix -c crate2nix generate && nix-build . -A docker --argstr dockerName "${EXPECTED_REGISTRY}/' + operator_name + '" && ./result/load-image | docker load',
+    'make regenerate-nix && nix-build . -A docker --argstr dockerName "${EXPECTED_REGISTRY}/' + operator_name + '" && ./result/load-image | docker load',
     deps=['rust', 'Cargo.toml', 'Cargo.lock', 'default.nix', "nix", 'build.rs', 'vendor'],
     ignore=['*.~undo-tree~'],
     # ignore=['result*', 'Cargo.nix', 'target', *.yaml],

--- a/template/default.nix
+++ b/template/default.nix
@@ -40,6 +40,7 @@
 , dockerTag ? null
 }:
 rec {
+  inherit cargo sources pkgs;
   build = cargo.allWorkspaceMembers;
   entrypoint = build+"/bin/stackable-${meta.operator.name}";
   crds = pkgs.runCommand "${meta.operator.name}-crds.yaml" {}

--- a/template/default.nix
+++ b/template/default.nix
@@ -40,7 +40,7 @@
 , dockerTag ? null
 }:
 rec {
-  inherit cargo sources pkgs;
+  inherit cargo sources pkgs meta;
   build = cargo.allWorkspaceMembers;
   entrypoint = build+"/bin/stackable-${meta.operator.name}";
   crds = pkgs.runCommand "${meta.operator.name}-crds.yaml" {}

--- a/template/default.nix
+++ b/template/default.nix
@@ -96,4 +96,11 @@ rec {
   # need to use vendored crate2nix because of https://github.com/kolloch/crate2nix/issues/264
   crate2nix = import sources.crate2nix {};
   tilt = pkgs.tilt;
+
+  regenerateNixLockfiles = pkgs.writeScriptBin "regenerate-nix-lockfiles"
+  ''
+    set -euo pipefail
+    echo Running crate2nix
+    ${crate2nix}/bin/crate2nix generate
+  ''; 
 }

--- a/template/shell.nix
+++ b/template/shell.nix
@@ -1,12 +1,12 @@
 let
   self = import ./. {};
-  inherit (self) sources pkgs;
+  inherit (self) sources pkgs meta;
 
   beku = pkgs.callPackage (sources."beku.py" + "/beku.nix") {};
   cargoDependencySetOfCrate = crate: [ crate ] ++ pkgs.lib.concatMap cargoDependencySetOfCrate (crate.dependencies ++ crate.buildDependencies);
   cargoDependencySet = pkgs.lib.unique (pkgs.lib.flatten (pkgs.lib.mapAttrsToList (crateName: crate: cargoDependencySetOfCrate crate.build) self.cargo.workspaceMembers));
 in pkgs.mkShell rec {
-  name = "{[ operator.name }]";
+  name = meta.operator.name;
 
   packages = with pkgs; [
     ## cargo et-al

--- a/template/shell.nix.j2
+++ b/template/shell.nix.j2
@@ -20,18 +20,10 @@ in pkgs.mkShell rec {
   ];
 
   # derivation runtime dependencies
-  buildInputs = pkgs.lib.concatMap (crate: crate.buildInputs) cargoDependencySet ++ [ pkgs.libz ];
+  buildInputs = pkgs.lib.concatMap (crate: crate.buildInputs) cargoDependencySet;
   
   # build time dependencies
   nativeBuildInputs = pkgs.lib.concatMap (crate: crate.nativeBuildInputs) cargoDependencySet ++ (with pkgs; [
-    # specific to secret-operator but should be discovered via crate2nix, but
-    # otherwise, we could include an operator-specific nix import for any extras
-    pkg-config
-    clang 
-    openssl
-    protobuf
-    krb5 
-
     git
     yq-go
     jq
@@ -49,4 +41,5 @@ in pkgs.mkShell rec {
   ]);
 
   LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+  BINDGEN_EXTRA_CLANG_ARGS = "-I${pkgs.glibc.dev}/include -I${pkgs.clang}/resource-root/include";
 }

--- a/template/shell.nix.j2
+++ b/template/shell.nix.j2
@@ -24,20 +24,19 @@ in pkgs.mkShell rec {
   
   # build time dependencies
   nativeBuildInputs = pkgs.lib.concatMap (crate: crate.nativeBuildInputs) cargoDependencySet ++ (with pkgs; [
-    git
-    yq-go
-    jq
-    kubectl
-    nix # this is impled, but needed in the pure env
-    kubernetes-helm
-    # tilt already defined in default.nix
-    docker
-    kind
-
-    kuttl
     beku
-    which
+    docker
     gettext # for the proper envsubst
+    git
+    jq
+    kind
+    kubectl
+    kubernetes-helm
+    kuttl
+    nix # this is implied, but needed in the pure env
+    # tilt already defined in default.nix
+    which
+    yq-go
   ]);
 
   LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";

--- a/template/shell.nix.j2
+++ b/template/shell.nix.j2
@@ -1,0 +1,52 @@
+let
+  self = import ./. {};
+  inherit (self) sources pkgs;
+
+  beku = pkgs.callPackage (sources."beku.py" + "/beku.nix") {};
+  cargoDependencySetOfCrate = crate: [ crate ] ++ pkgs.lib.concatMap cargoDependencySetOfCrate (crate.dependencies ++ crate.buildDependencies);
+  cargoDependencySet = pkgs.lib.unique (pkgs.lib.flatten (pkgs.lib.mapAttrsToList (crateName: crate: cargoDependencySetOfCrate crate.build) self.cargo.workspaceMembers));
+in pkgs.mkShell rec {
+  name = "{[ operator.name }]";
+
+  packages = with pkgs; [
+    ## cargo et-al
+    rustup # this breaks pkg-config if it is in the nativeBuildInputs
+
+    ## Extra dependencies for use in a pure env (nix-shell --pure)
+    ## These are mosuly useful for maintainers of this shell.nix
+    ## to ensure all the dependencies are caught.
+    # cacert
+    # vim nvim nano
+  ];
+
+  # derivation runtime dependencies
+  buildInputs = pkgs.lib.concatMap (crate: crate.buildInputs) cargoDependencySet ++ [ pkgs.libz ];
+  
+  # build time dependencies
+  nativeBuildInputs = pkgs.lib.concatMap (crate: crate.nativeBuildInputs) cargoDependencySet ++ (with pkgs; [
+    # specific to secret-operator but should be discovered via crate2nix, but
+    # otherwise, we could include an operator-specific nix import for any extras
+    pkg-config
+    clang 
+    openssl
+    protobuf
+    krb5 
+
+    git
+    yq-go
+    jq
+    kubectl
+    nix # this is impled, but needed in the pure env
+    kubernetes-helm
+    # tilt already defined in default.nix
+    docker
+    kind
+
+    kuttl
+    beku
+    which
+    gettext # for the proper envsubst
+  ]);
+
+  LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+}


### PR DESCRIPTION
This is based on what I was doing in stackabletech/secret-operator#344, but to extend it out to all operators.

> [!IMPORTANT]
> Each operator will need to have `Cargo.nix` checked in to be able to make use of these changes. Otherwise they will get the following error when running `nix-shell`:
> ```
> error: getting status of '.../Cargo.nix': No such file or directory
> ```
>
> Run:
> ```sh
> make regenerate-nix
> git add Cargo.nix crate-hashes.json
> git commit -m "add crate2nix generated files"
>
> niv add stackabletech/beku.py
> git add nix/source.json
> git commit -m "add niv dependencies"
> ```

It includes some packages that are only needed for secret-operator:
- They are supposed to already be discovered/provided by default.nix, but I can't get it working.
- If we can't fix the above point, then perhaps we can call out to another nix file that lists additional packages needed by that operator (but then most of then would need to provide a basically empty extra nix file).

---

This will also skip spell-checking in listed generated files.

![image](https://github.com/stackabletech/operator-templating/assets/10092581/d38aeb91-ee14-44bf-bf35-272e3d166340)