### PR TITLE
ci: Add nix install action

### DIFF
--- a/.github/workflows/generate_prs.yml
+++ b/.github/workflows/generate_prs.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # tag=v4.1.1
+      - uses: cachix/install-nix-action@6004951b182f8860210c8d6f0d808ec5b1a33d28 # tag=v25
       - name: Install Ansible
         env:
           DEBIAN_FRONTEND: noninteractive


### PR DESCRIPTION
This fixes the last PR #323 which errors with:

```
TASK [Operator [airflow-operator] regenerate crate2nix] ************************
fatal: [localhost]: FAILED! => {"changed": true, "cmd": ["make", "regenerate-nix"], "delta": "0:00:00.204998", "end": "2024-02-21 12:43:50.841070", "msg": "non-zero return code", "rc": 2, "start": "2024-02-21 12:43:50.636072", "stderr": "bash: line 1: nix: command not found\nmake: *** [Makefile:136: regenerate-nix] Error 127", "stderr_lines": ["bash: line 1: nix: command not found", "make: *** [Makefile:136: regenerate-nix] Error 127"], "stdout": "nix run -f . regenerateNixLockfiles", "stdout_lines": ["nix run -f . regenerateNixLockfiles"]}
```
