### PR TITLE
fix: nix bash script

### DIFF
--- a/.github/workflows/generate_prs.yml
+++ b/.github/workflows/generate_prs.yml
@@ -27,7 +27,7 @@ jobs:
             sudo apt-add-repository ppa:ansible/ansible -y && \
             sudo apt install -y ansible
 
-      # NOTE (@NickLarsenNZ): This could be removed in favour of nix-shell and rrbutani/use-nix-shell-action
+      # NOTE (@NickLarsenNZ): This could be removed in favor of nix-shell and rrbutani/use-nix-shell-action
       - name: Install deps for operators
         run: |
           sudo apt-get install \

--- a/.github/workflows/generate_prs.yml
+++ b/.github/workflows/generate_prs.yml
@@ -27,6 +27,7 @@ jobs:
             sudo apt-add-repository ppa:ansible/ansible -y && \
             sudo apt install -y ansible
 
+      # NOTE (@NickLarsenNZ): This could be removed in favour of nix-shell and rrbutani/use-nix-shell-action
       - name: Install deps for operators
         run: |
           sudo apt-get install \

--- a/.github/workflows/generate_prs.yml
+++ b/.github/workflows/generate_prs.yml
@@ -8,7 +8,7 @@ on:
         description: "Message to include in the generated commits:"
         required: true
       dry-run:
-        description: ""
+        description: "Dry Run (PRs are not generated)"
         type: boolean
         default: true
 

--- a/.github/workflows/generate_prs.yml
+++ b/.github/workflows/generate_prs.yml
@@ -7,6 +7,10 @@ on:
       message:
         description: "Message to include in the generated commits:"
         required: true
+      dry-run:
+        description: ""
+        type: boolean
+        default: true
 
 jobs:
   create-prs:
@@ -49,9 +53,17 @@ jobs:
 
       # Generate PRs
       - name: Run playbook
+        if: ${{ !inputs.dry-run }}
         run: |
           # Funnel via JSON to ensure that values are escaped properly
           echo '{}' | jq '{commit_hash: $ENV.GITHUB_SHA, reason: $ENV.REASON, base_dir: $pwd,  gh_access_token: $ENV.GH_ACCESS_TOKEN}' --arg pwd "$(pwd)" > vars.json
           ansible-playbook playbook/playbook.yaml --extra-vars "@vars.json"
         env:
           GH_ACCESS_TOKEN: ${{ secrets.gh_access_token }}
+
+      # Do Not Generate PRs
+      - name: Run playbook (dry-run)
+        if: ${{ inputs.dry-run }}
+        run: ./test
+        env:
+          GH_ACCESS_TOKEN: ""

--- a/template/default.nix
+++ b/template/default.nix
@@ -99,6 +99,7 @@ rec {
 
   regenerateNixLockfiles = pkgs.writeScriptBin "regenerate-nix-lockfiles"
   ''
+    #!/usr/bin/env bash
     set -euo pipefail
     echo Running crate2nix
     ${crate2nix}/bin/crate2nix generate


### PR DESCRIPTION
- add shebang to nix bash script (github actions runs `sh` by default, and we need `set -o pipefail`.
- add a dry-run workflow input so we can test things without raising a million PRs

![image](https://github.com/stackabletech/operator-templating/assets/10092581/014885e3-d98c-4e1e-9c71-a1971abbe7e5)
