### PR TITLE
ci: add nix install action

### DIFF
--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -328,6 +328,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: recursive
+      - uses: cachix/install-nix-action@6004951b182f8860210c8d6f0d808ec5b1a33d28 # tag=v25
       - uses: dtolnay/rust-toolchain@be73d7920c329f220ce78e0234b8f96b7ae60248
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}


### PR DESCRIPTION
The operator builds fail when they run `make -e publish` which calls the `build` make target, which then calls `regenerate-nix` target.

@nightkr do we want the build to be `regenerating-nix`? Is it possible that the builds don't then use the versions/hashes in the committed lockfiles?
