### PR TITLE
feat(run_tests.sh): install operators as needed by the tests.

### DIFF
--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -364,6 +364,7 @@ jobs:
 
   openshift_preflight:
     name: Run the OpenShift Preflight check on the published images
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     needs:
       - package_and_publish
     runs-on: ubuntu-latest

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -386,7 +386,7 @@ jobs:
     needs:
       - package_and_publish
     env:
-      STACKABLECT_VERSION: "23.11.3"
+      STACKABLECTL_VERSION: "23.11.3"
       KUTTL_VERSION: "0.15.0"
     strategy:
       fail-fast: false

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -412,7 +412,7 @@ jobs:
           # Install requirements for the run_tests.sh script.
           PATH=/usr/bin:$PATH
 
-          wget --no-verbose https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-"$STACKABLECT_VERSION"/stackablectl-x86_64-unknown-linux-gnu
+          wget --no-verbose https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-"$STACKABLECTL_VERSION"/stackablectl-x86_64-unknown-linux-gnu
           chmod +x stackablectl-x86_64-unknown-linux-gnu
           sudo mv stackablectl-x86_64-unknown-linux-gnu /usr/bin/stackablectl
 

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -380,11 +380,14 @@ jobs:
       - name: "Passed?"
         run: '[ "$(./preflight-linux-amd64 check container "$IMAGE_TAG" | jq -r .passed)" == true ]'
 
-  openshift_tests:
+  integration_tests:
     name: Run integration tests
     if: ${{ !github.event.pull_request.head.repo.fork }}
     needs:
       - package_and_publish
+    env:
+      STACKABLECT_VERSION: "23.11.3"
+      KUTTL_VERSION: "0.15.0"
     strategy:
       fail-fast: false
       matrix:
@@ -409,13 +412,13 @@ jobs:
           # Install requirements for the run_tests.sh script.
           PATH=/usr/bin:$PATH
 
-          wget --no-verbose https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-23.11.3/stackablectl-x86_64-unknown-linux-gnu
+          wget --no-verbose https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-"$STACKABLECT_VERSION"/stackablectl-x86_64-unknown-linux-gnu
           chmod +x stackablectl-x86_64-unknown-linux-gnu
           sudo mv stackablectl-x86_64-unknown-linux-gnu /usr/bin/stackablectl
 
-          wget --no-verbose https://github.com/kudobuilder/kuttl/releases/download/v0.15.0/kubectl-kuttl_0.15.0_linux_x86_64
-          chmod +x kubectl-kuttl_0.15.0_linux_x86_64
-          sudo mv kubectl-kuttl_0.15.0_linux_x86_64 /usr/bin/kubectl-kuttl
+          wget --no-verbose https://github.com/kudobuilder/kuttl/releases/download/v"$KUTTL_VERSION"/kubectl-kuttl_"$KUTTL_VERSION"_linux_x86_64
+          chmod +x kubectl-kuttl_"$KUTTL_VERSION"_linux_x86_64
+          sudo mv kubectl-kuttl_"$KUTTL_VERSION"_linux_x86_64 /usr/bin/kubectl-kuttl
           kubectl-kuttl version
 
       - name: Create Cluster

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -393,7 +393,7 @@ jobs:
             distribution: openshift,
             version: 4.14.0-okd,
             nodes: 3,
-            instances: r1.2xlarge
+            instances: r1.large
           }]
     runs-on: ubuntu-22.04
     steps:
@@ -436,7 +436,7 @@ jobs:
         run: |
           PATH=/usr/bin:$PATH
 
-          scripts/run_tests.sh openshift
+          scripts/run_tests.sh --test-suite openshift --parallel 2
 
       - name: Remove Cluster
         if: always()
@@ -446,3 +446,4 @@ jobs:
         with:
           api-token: ${{ secrets.REPLICATED_API_TOKEN }}
           cluster-id: ${{ steps.create-cluster.outputs.cluster-id }}
+

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -360,6 +360,7 @@ jobs:
 
   openshift_preflight:
     name: Run the OpenShift Preflight check on the published images
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     needs:
       - package_and_publish
     runs-on: ubuntu-latest

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -374,3 +374,69 @@ jobs:
         run: ./preflight-linux-amd64 check container "$IMAGE_TAG" > preflight.out
       - name: "Passed?"
         run: '[ "$(./preflight-linux-amd64 check container "$IMAGE_TAG" | jq -r .passed)" == true ]'
+
+  openshift_tests:
+    name: Run integration tests
+    needs:
+      - package_and_publish
+    strategy:
+      fail-fast: false
+      matrix:
+        cluster: [
+          {
+            distribution: openshift,
+            version: 4.14.0-okd,
+            nodes: 3,
+            instances: r1.2xlarge
+          }]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # tag=v5.0.0
+        with:
+          python-version: '3.11'
+      - run: pip install beku-stackabletech
+
+      - name: Install test requirements
+        run: |
+          # Install requirements for the run_tests.sh script.
+          PATH=/usr/bin:$PATH
+
+          wget --no-verbose https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-23.11.3/stackablectl-x86_64-unknown-linux-gnu
+          chmod +x stackablectl-x86_64-unknown-linux-gnu
+          sudo mv stackablectl-x86_64-unknown-linux-gnu /usr/bin/stackablectl
+
+          wget --no-verbose https://github.com/kudobuilder/kuttl/releases/download/v0.15.0/kubectl-kuttl_0.15.0_linux_x86_64
+          chmod +x kubectl-kuttl_0.15.0_linux_x86_64
+          sudo mv kubectl-kuttl_0.15.0_linux_x86_64 /usr/bin/kubectl-kuttl
+          kubectl-kuttl version
+
+      - name: Create Cluster
+        id: create-cluster
+        uses: replicatedhq/replicated-actions/create-cluster@v1
+        with:
+          api-token: ${{ secrets.REPLICATED_API_TOKEN }}
+          kubernetes-distribution: ${{ matrix.cluster.distribution }}
+          kubernetes-version: ${{ matrix.cluster.version }}
+          cluster-name: ${{ github.ref_name }}-${{ matrix.cluster.distribution }}-${{ matrix.cluster.version }}
+          timeout-minutes: 10
+          ttl: 2h
+          nodes: ${{ matrix.cluster.nodes }}
+          instance-type: ${{ matrix.cluster.instances }}
+          export-kubeconfig: true
+
+      - name: Run a test
+        run: |
+          PATH=/usr/bin:$PATH
+
+          scripts/run_tests.sh openshift
+
+      - name: Remove Cluster
+        if: always()
+        id: remove-cluster
+        uses: replicatedhq/replicated-actions/remove-cluster@v1
+        continue-on-error: true # It could be that the cluster is already removed
+        with:
+          api-token: ${{ secrets.REPLICATED_API_TOKEN }}
+          cluster-id: ${{ steps.create-cluster.outputs.cluster-id }}

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -449,4 +449,3 @@ jobs:
         with:
           api-token: ${{ secrets.REPLICATED_API_TOKEN }}
           cluster-id: ${{ steps.create-cluster.outputs.cluster-id }}
-

--- a/template/scripts/run_tests.sh
+++ b/template/scripts/run_tests.sh
@@ -1,24 +1,91 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
+#
+# Run the integration test suite for this operator.
+#
+# If a "tests/release.yaml" file is present, it will install the operators listed
+# in the release file first. The name of the test suite in that file must be "tests".
+# Since each operator test suite has different dependencies, the "tests/release.yaml"
+# file is not included in this repository.
+#
+# Optionally you can provide a specific test suite to run and even a specific
+# test name.
+#
+# Example 1 - run all tests of the openshift suite.
+#
+# ./scripts/run_tests.sh openshift
+#
+# Example 2 - run a specific smoke test of the openshift suite.
+#
+# ./scripts/run_tests.sh \
+#   openshift \
+#   smoke_trino-439_hive-3.1.3_opa-0.61.0_hdfs-3.3.6_zookeeper-3.8.3_s3-use-tls-true_openshift-true
+#
 
-# Check if the test expansion tool beku is installed
 set +e
-which beku > /dev/null 2>&1
-beku_installed=$?
-set -e
-if [ $beku_installed -ne 0 ]; then
-  echo "Please install beku.py to run the tests, see https://github.com/stackabletech/beku.py"
-  exit 1
-fi
 
-echo "Using beku version: $(beku --version)"
+REPO_ROOT=$(dirname $(dirname $0))
+TEST_ROOT="$REPO_ROOT/tests/_work"
+RELEASE_FILE="$REPO_ROOT/tests/release.yaml"
+BEKU_TEST_SUITE="$1"
+KUTTL_TEST="$2"
 
-# cleanup any old tests
-rm -rf tests/_work
+is_installed() {
+	local command="$1"
+	local install_url="$2"
 
-# Expand the tests
-beku
+	which "$command" >/dev/null 2>&1
+	if [ $? -ne 0 ]; then
+		echo "Command [$command] not found. To install it, please see $install_url"
+		exit 1
+	fi
+}
 
-# Run tests, pass the params
-pushd tests/_work
-kubectl kuttl test "$@"
-popd
+install_operators() {
+	if [ -f "$RELEASE_FILE" ]; then
+		echo "Installing operators with stackablectl version: $(stackablectl --version)"
+		stackablectl release install --release-file "$RELEASE_FILE" tests
+	else
+		echo "No tests/release.yaml found, skipping operator installation"
+	fi
+}
+
+expand_test_suite() {
+	# Expand the tests
+	echo "Running beku version: $(beku --version)"
+	if [ -z "$BEKU_TEST_SUITE" ]; then
+		echo "No test suite specified, expanding all tests"
+		beku
+	else
+		echo "Expanding test suite: $BEKU_TEST_SUITE"
+		beku --suite "$BEKU_TEST_SUITE"
+	fi
+}
+
+run_tests() {
+	echo "Running kuttl version: $(kubectl kuttl --version)"
+
+	cd $TEST_ROOT
+
+	if [ -z "$BEKU_TEST_SUITE" ]; then
+		echo "No test specified, running all tests"
+		kubectl kuttl test
+	else
+		echo "Running test: $KUTTL_TEST"
+		kubectl kuttl test --test "$KUTTL_TEST"
+	fi
+
+	cd -
+}
+
+main() {
+	is_installed beku "https://github.com/stackabletech/beku.py"
+	is_installed stackablectl "https://github.com/stackabletech/stackable-cockpit/blob/main/rust/stackablectl/README.md"
+	is_installed kubectl "https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/"
+	is_installed kubectl-kuttl "https://kuttl.dev/"
+
+	expand_test_suite
+	install_operators
+	run_tests
+}
+
+main

--- a/template/scripts/run_tests.sh
+++ b/template/scripts/run_tests.sh
@@ -14,11 +14,11 @@
 #
 # ./scripts/run_tests.sh --test-suite openshift --parallel 2
 #
-# Example 2 - run a specific smoke test of the openshift suite and skip resource deletion.
+# Example 2 - run all tests that start with "smoke" in the name of the openshift suite and skip resource deletion.
 #
 # ./scripts/run_tests.sh \
 #   --test-suite openshift \
-#   --test smoke_trino-439_hive-3.1.3_opa-0.61.0_hdfs-3.3.6_zookeeper-3.8.3_s3-use-tls-true_openshift-true \
+#   --test smoke \
 #   --skip-delete
 #
 
@@ -93,7 +93,16 @@ run_tests() {
 }
 
 usage() {
-	echo "Usage: $0 [--test-suite <test-suite>] [--test <test-name>] [--skip-delete] [--parallel <number>] [--skip-release]"
+	cat <<USAGE
+  Usage:
+     run_tests.sh [options]"
+  Options:
+    --test-suite <test-suite>  Run a test suite from the test_definition.yaml file. Default is all tests.
+    --test <test-name>         Run a specific test or a set of tests.
+    --skip-delete              Skip resource deletion after the test run.
+    --parallel <number>        Run tests in parallel. Default is to run all tests in parallel.
+    --skip-release             Skip the operator installation.
+USAGE
 }
 
 parse_args() {

--- a/template/scripts/run_tests.sh
+++ b/template/scripts/run_tests.sh
@@ -149,4 +149,4 @@ main() {
 	run_tests
 }
 
-main $@
+main "$@"

--- a/template/scripts/run_tests.sh
+++ b/template/scripts/run_tests.sh
@@ -95,7 +95,7 @@ run_tests() {
 usage() {
 	cat <<USAGE
   Usage:
-     run_tests.sh [options]"
+     run_tests.sh [options]
   Options:
     --test-suite <test-suite>  Run a test suite from the test_definition.yaml file. Default is all tests.
     --test <test-name>         Run a specific test or a set of tests.

--- a/template/scripts/run_tests.sh
+++ b/template/scripts/run_tests.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 #
 # Run the integration test suite for this operator.
 #
@@ -23,7 +23,8 @@
 
 set +e
 
-REPO_ROOT=$(dirname $(dirname "$0"))
+DIR_NAME=$(dirname "$0")
+REPO_ROOT=$(dirname "$DIR_NAME")
 TEST_ROOT="$REPO_ROOT/tests/_work"
 RELEASE_FILE="$REPO_ROOT/tests/release.yaml"
 BEKU_TEST_SUITE="$1"
@@ -33,8 +34,7 @@ is_installed() {
 	local command="$1"
 	local install_url="$2"
 
-	which "$command" >/dev/null 2>&1
-	if [ $? -ne 0 ]; then
+	if ! which "$command" >/dev/null 2>&1; then
 		echo "Command [$command] not found. To install it, please see $install_url"
 		exit 1
 	fi
@@ -64,7 +64,7 @@ expand_test_suite() {
 run_tests() {
 	echo "Running kuttl version: $(kubectl kuttl --version)"
 
-	cd "$TEST_ROOT" || exit
+	pushd "$TEST_ROOT" || exit
 
 	if [ -z "$BEKU_TEST_SUITE" ]; then
 		echo "No test specified, running all tests"
@@ -74,7 +74,7 @@ run_tests() {
 		kubectl kuttl test --test "$KUTTL_TEST"
 	fi
 
-	cd - || exit
+	popd || exit
 }
 
 main() {

--- a/template/scripts/run_tests.sh
+++ b/template/scripts/run_tests.sh
@@ -28,6 +28,7 @@ DIR_NAME=$(dirname "$0")
 REPO_ROOT=$(dirname "$DIR_NAME")
 TEST_ROOT="$REPO_ROOT/tests/_work"
 RELEASE_FILE="$REPO_ROOT/tests/release.yaml"
+STACKABLECTL_SKIP_RELEASE=""
 BEKU_TEST_SUITE=""
 KUTTL_TEST=""
 KUTTL_SKIP_DELETE=""
@@ -44,6 +45,11 @@ is_installed() {
 }
 
 install_operators() {
+	if [ -n "$STACKABLECTL_SKIP_RELEASE" ]; then
+		echo "Skipping operator installation"
+		return
+	fi
+
 	if [ -f "$RELEASE_FILE" ]; then
 		echo "Installing operators with stackablectl version: $(stackablectl --version)"
 		stackablectl release install --release-file "$RELEASE_FILE" tests
@@ -87,12 +93,15 @@ run_tests() {
 }
 
 usage() {
-	echo "Usage: $0 [--test-suite <test-suite>] [--test <test-name>] [--skip-delete] [--parallel <number>]"
+	echo "Usage: $0 [--test-suite <test-suite>] [--test <test-name>] [--skip-delete] [--parallel <number>] [--skip-release]"
 }
 
 parse_args() {
 	while [[ "$#" -gt 0 ]]; do
 		case $1 in
+		--skip-release)
+			STACKABLECTL_SKIP_RELEASE="true"
+			;;
 		--skip-delete)
 			KUTTL_SKIP_DELETE="true"
 			;;

--- a/template/scripts/run_tests.sh
+++ b/template/scripts/run_tests.sh
@@ -62,16 +62,16 @@ expand_test_suite() {
 }
 
 run_tests() {
-	echo "Running kuttl version: $(kubectl kuttl --version)"
+	echo "Running kuttl version: $(kubectl-kuttl --version)"
 
 	pushd "$TEST_ROOT" || exit
 
 	if [ -z "$BEKU_TEST_SUITE" ]; then
 		echo "No test specified, running all tests"
-		kubectl kuttl test
+		kubectl-kuttl test --parallel 2
 	else
 		echo "Running test: $KUTTL_TEST"
-		kubectl kuttl test --test "$KUTTL_TEST"
+		kubectl-kuttl test --parellel 2 --test "$KUTTL_TEST"
 	fi
 
 	popd || exit

--- a/template/scripts/run_tests.sh
+++ b/template/scripts/run_tests.sh
@@ -14,7 +14,7 @@
 #
 # ./scripts/run_tests.sh --test-suite openshift --parallel 2
 #
-# Example 2 - run all tests that contain "smoke" in the name of the openshift suite and skip resource deletion.
+# Example 2 - run all tests that contain the word "smoke" in the openshift suite and skip resource deletion.
 #
 # ./scripts/run_tests.sh \
 #   --test-suite openshift \

--- a/template/scripts/run_tests.sh
+++ b/template/scripts/run_tests.sh
@@ -14,7 +14,7 @@
 #
 # ./scripts/run_tests.sh --test-suite openshift --parallel 2
 #
-# Example 2 - run all tests that start with "smoke" in the name of the openshift suite and skip resource deletion.
+# Example 2 - run all tests that contain "smoke" in the name of the openshift suite and skip resource deletion.
 #
 # ./scripts/run_tests.sh \
 #   --test-suite openshift \

--- a/template/scripts/run_tests.sh
+++ b/template/scripts/run_tests.sh
@@ -23,7 +23,7 @@
 
 set +e
 
-REPO_ROOT=$(dirname $(dirname $0))
+REPO_ROOT=$(dirname $(dirname "$0"))
 TEST_ROOT="$REPO_ROOT/tests/_work"
 RELEASE_FILE="$REPO_ROOT/tests/release.yaml"
 BEKU_TEST_SUITE="$1"
@@ -64,7 +64,7 @@ expand_test_suite() {
 run_tests() {
 	echo "Running kuttl version: $(kubectl kuttl --version)"
 
-	cd $TEST_ROOT
+	cd "$TEST_ROOT" || exit
 
 	if [ -z "$BEKU_TEST_SUITE" ]; then
 		echo "No test specified, running all tests"
@@ -74,7 +74,7 @@ run_tests() {
 		kubectl kuttl test --test "$KUTTL_TEST"
 	fi
 
-	cd -
+	cd - || exit
 }
 
 main() {

--- a/template/scripts/run_tests.sh
+++ b/template/scripts/run_tests.sh
@@ -88,7 +88,7 @@ run_tests() {
 	fi
 
 	pushd "$TEST_ROOT" || exit
-	kubectl-kuttl ${OPTS[*]}
+	kubectl-kuttl "${OPTS[*]}"
 	popd || exit
 }
 


### PR DESCRIPTION
Install tests as needed by the operator test suite. 

This makes the operator installation the responsibility of the test suite.

Advantages:

* PR tests can now reference opreators from other PRs.
* Only install the operators that are needed for by the test suite.
* Running the integration tests from GH actions do not require workflows to know
  about the operator installation.

Operator installation is optional and only done if a file named `tests/release.yaml` is found.

Here is an `release.yaml` example for the `trino-operator`

```yaml
# Contains all operators required to run the test suite.
---
releases:
  # Do not change the name of the release as it's referenced from run_tests.sh
  tests:
    releaseDate: 1970-01-01
    description: Integration test
    products:
      commons:
        operatorVersion: 0.0.0-dev
      secret:
        operatorVersion: 0.0.0-dev
      listener:
        operatorVersion: 0.0.0-dev
      zookeeper:
        operatorVersion: 0.0.0-dev
      hdfs:
        operatorVersion: 0.0.0-dev
      hive:
        operatorVersion: 0.0.0-dev
      opa:
        operatorVersion: 0.0.0-dev
      trino:
        operatorVersion: 0.0.0-dev
```

