### PR TITLE
ci(template): Fork awareness

### DIFF
--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -351,15 +351,20 @@ jobs:
         uses: sigstore/cosign-installer@9614fae9e5c5eddabb09f90a270fcb487c9f7149 # tag=v3.3.0
       - name: Install syft
         uses: anchore/sbom-action/download-syft@24b0d5238516480139aa8bc6f92eeb7b54a9eb0a # tag=v0.15.5
+      - name: Build Docker image and Helm chart
+        run: make -e build
       - name: Publish Docker image and Helm chart
+        if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
         run: make -e publish
         # Output the name of the published image to the Job output for later use
       - id: printtag
         name: Output image name and tag
+        if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
         run: echo "IMAGE_TAG=$(make -e print-docker-tag)" >> $GITHUB_OUTPUT
 
   openshift_preflight:
     name: Run the OpenShift Preflight check on the published images
+    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
     needs:
       - package_and_publish
     runs-on: ubuntu-latest

--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -148,7 +148,7 @@ regenerate-nix:
 
 build: regenerate-charts regenerate-nix helm-package docker-build
 
-publish: build docker-publish helm-publish
+publish: docker-publish helm-publish
 
 run-dev:
 	kubectl apply -f deploy/stackable-operators-ns.yaml


### PR DESCRIPTION
- Remove the `build` target from the `publish` target in Makefile
- Do not run `make -e publish` if is is a PR from a fork (which has no access to secrets)
  - Also don't run the openshift preflight checks which expects there to be an image to pull

---

Tested here:
- https://github.com/stackabletech/hbase-operator/pull/458
- https://github.com/stackabletech/hbase-operator/actions/runs/8078056432

![image](https://github.com/stackabletech/operator-templating/assets/10092581/c47dbab1-648c-4eb7-a2cc-275ed97da65f)
