### PR TITLE
fix(template): fork detection that still works with tag/merge

### DIFF
--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -354,17 +354,17 @@ jobs:
       - name: Build Docker image and Helm chart
         run: make -e build
       - name: Publish Docker image and Helm chart
-        if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         run: make -e publish
         # Output the name of the published image to the Job output for later use
       - id: printtag
         name: Output image name and tag
-        if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         run: echo "IMAGE_TAG=$(make -e print-docker-tag)" >> $GITHUB_OUTPUT
 
   openshift_preflight:
     name: Run the OpenShift Preflight check on the published images
-    if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     needs:
       - package_and_publish
     runs-on: ubuntu-latest


### PR DESCRIPTION
This fixes #334 which essentially broke push to `main` and tagging. It just happened to work for PRs.

This works as expected (though I can't test the merge to main/tag easily):

### PR from a Fork

![image](https://github.com/stackabletech/operator-templating/assets/10092581/13268e42-09a1-4e0c-9425-56c62e1a7259)

### PR from a branch on the same repository

![image](https://github.com/stackabletech/operator-templating/assets/10092581/6e56a790-a475-4f02-8d0a-9652a882d4d3)
