### PR TITLE
Fix shebang of run-tests script

### DIFF
--- a/template/scripts/run-tests
+++ b/template/scripts/run-tests
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 # vim: filetype=python syntax=python tabstop=4 expandtab
 
 import argparse


### PR DESCRIPTION
Fix shebang of run-tests script

The `env` command is located in `/usr/bin` on most distros.