### PR TITLE
chore: add arch for preflight

### DIFF
--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -376,6 +376,8 @@ jobs:
           wget https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.9.1/preflight-linux-amd64
           chmod +x preflight-linux-amd64
       - name: Check container
-        run: ./preflight-linux-amd64 check container "$IMAGE_TAG" > preflight.out
+        run: |
+          ARCH_FOR_PREFLIGHT="$(arch | sed -e 's#x86_64#amd64#' | sed -e 's#aarch64#arm64#')"
+          ./preflight-linux-amd64 check container "$IMAGE_TAG" --platform "${ARCH_FOR_PREFLIGHT}" > preflight.out
       - name: "Passed?"
-        run: '[ "$(./preflight-linux-amd64 check container "$IMAGE_TAG" | jq -r .passed)" == true ]'
+        run: '[ "$(./preflight-linux-amd64 check container "$IMAGE_TAG" --platform "${ARCH_FOR_PREFLIGHT}" | jq -r .passed)" == true ]'


### PR DESCRIPTION
Adds a variable that selects the target architecture, as is done for docker-images https://github.com/stackabletech/docker-images/pull/626. N.B. preflight does not expect a `linux/` prefix but just `amd64` or `arm64`.
Fixes https://github.com/stackabletech/issues/issues/559.
Tested here:https://github.com/stackabletech/hive-operator/pull/450/files.
Dry-run for PRs: https://github.com/stackabletech/operator-templating/actions/runs/8881229144