### PR TITLE
chore(nix): Update dependencies

### DIFF
--- a/template/nix/sources.json
+++ b/template/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": null,
         "owner": "stackabletech",
         "repo": "beku.py",
-        "rev": "215bc8b90989d6819ee65c99c6f64e9312fbb8eb",
-        "sha256": "14idkbfvx4y2aq4gyzib2m2kparhcf5r9c6zd2wv9f9wf6xyzhdx",
+        "rev": "f5ef0199b0c3c8aa277a275a9d3c624eb5804f27",
+        "sha256": "1yx3ypn312p27d6zfnqcfnkarj9hirmm6gij9345kgnx5p2xfb1d",
         "type": "tarball",
-        "url": "https://github.com/stackabletech/beku.py/archive/215bc8b90989d6819ee65c99c6f64e9312fbb8eb.tar.gz",
+        "url": "https://github.com/stackabletech/beku.py/archive/f5ef0199b0c3c8aa277a275a9d3c624eb5804f27.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "crate2nix": {

--- a/template/nix/sources.json
+++ b/template/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ad7efee13e0d216bf29992311536fce1d3eefbef",
-        "sha256": "0mw8wjpllwgajwakl2rh5fhbhfsr9vdlzf393rx4y1b6072pqjrr",
+        "rev": "af8b9db5c00f1a8e4b83578acc578ff7d823b786",
+        "sha256": "0kd64p8i1gmgdjfdag2fvj4gfcsk0wa3h7w7j5l6b2yxr9plnhpm",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/ad7efee13e0d216bf29992311536fce1d3eefbef.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/af8b9db5c00f1a8e4b83578acc578ff7d823b786.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
- Use fixed beku version from stackabletech/beku.py#23
- Update crate2nix and nixpkgs