### PR TITLE
chore: Use uname instead of arch in Makefile

### DIFF
--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -12,7 +12,7 @@
 TAG    := $(shell git rev-parse --short HEAD)
 OPERATOR_NAME := {[ operator.name }]
 VERSION := $(shell cargo metadata --format-version 1 | jq -r '.packages[] | select(.name=="stackable-${OPERATOR_NAME}") | .version')
-ARCH := $(shell arch | sed -e 's#x86_64#amd64#' | sed -e 's#aarch64#arm64#')
+ARCH := $(shell uname -m | sed -e 's#x86_64#amd64#' | sed -e 's#aarch64#arm64#')
 
 DOCKER_REPO := docker.stackable.tech
 ORGANIZATION := stackable


### PR DESCRIPTION
[NixOS does not ship these by default](https://github.com/coreutils/coreutils/blob/684db6cb9b06cbb4f246152da427da6f47aa16cc/build-aux/gen-lists-of-programs.sh#L12-L22) and arch is only a wrapper around `uname -m` anyway