### PR TITLE
Allow the Unicode-3.0 license

### DIFF
--- a/template/deny.toml
+++ b/template/deny.toml
@@ -32,6 +32,7 @@ allow = [
     "LicenseRef-webpki",
     "MIT",
     "MPL-2.0",
+    "Unicode-3.0",
     "Unicode-DFS-2016",
     "Zlib",
     "Unlicense",


### PR DESCRIPTION
Allow the Unicode-3.0 license

This license is required after upgrading the dependencies with `cargo update`.

Without this entry in deny.toml, `cargo deny check licenses` throws the following error:

```
error[rejected]: failed to satisfy license requirements                                                                                                                       10:05:25 [26/996]
  ┌─ registry+https://github.com/rust-lang/crates.io-index#zerovec-derive@0.10.2:4:12
  │
4 │ license = "Unicode-3.0"
  │            ^^^^^^^^^^^
  │            │
  │            license expression retrieved via Cargo.toml `license`
  │            rejected: not explicitly allowed
  │
  = Unicode-3.0 - Unicode License v3:
  =   - OSI approved
  = zerovec-derive v0.10.2
    └── zerovec v0.10.2
        └── icu_collections v1.5.0
            └── icu_normalizer v1.5.0
                └── idna v1.0.0
                    └── url v2.5.1
                        └── stackable-operator v0.69.3 (*)
```

The license can be seen here: https://github.com/unicode-org/icu4x/blob/main/LICENSE