### PR TITLE
Increase the default timeout for integration test steps

### DIFF
--- a/template/tests/kuttl-test.yaml.jinja2
+++ b/template/tests/kuttl-test.yaml.jinja2
@@ -14,9 +14,10 @@ parallel: 2
 # deleted, and, if not overridden, in TestSteps, TestAsserts, and
 # Commands. If not set, the timeout is 30 seconds by default.
 #
-# The deletion of a namespace can take a while until all resources are
-# gracefully shut down. If the timeout is reached in the meantime, even
-# a successful test case is considered a failure.
+# The deletion of a namespace can take a while until all resources,
+# especially PersistentVolumeClaims, are gracefully shut down. If the
+# timeout is reached in the meantime, even a successful test case is
+# considered a failure.
 #
 # For instance, the termination grace period of the Vector aggregator in
 # the logging tests is set to 60 seconds. If there are logs entries
@@ -24,4 +25,4 @@ parallel: 2
 # the VECTOR_AGGREGATOR environment variable, then the test aggregator
 # uses this period of time by trying to forward the events. In this
 # case, deleting a namespace with several Pods takes about 90 seconds.
-timeout: 120
+timeout: 300


### PR DESCRIPTION
Increase the default timeout for integration test steps from 2 to 5 minutes

This timeout is also used for deleting namespaces. If a test succeeds but its namespace cannot be deleted in time, then the test still counts as failed.

```
    logger.go:42: 11:54:15 | smoke_hbase-2.4.17_hdfs-3.3.6_zookeeper-3.8.4_listener-class-external-unstable_openshift-false/60-test-phoenix | [SUCCESS] Phoenix test was successful!
    logger.go:42: 11:54:15 | smoke_hbase-2.4.17_hdfs-3.3.6_zookeeper-3.8.4_listener-class-external-unstable_openshift-false/60-test-phoenix | test step completed 60-test-phoenix
    logger.go:42: 11:54:15 | smoke_hbase-2.4.17_hdfs-3.3.6_zookeeper-3.8.4_listener-class-external-unstable_openshift-false | skipping kubernetes event logging
    logger.go:42: 11:54:16 | smoke_hbase-2.4.17_hdfs-3.3.6_zookeeper-3.8.4_listener-class-external-unstable_openshift-false | Deleting namespace: kuttl-test-suited-drake
    case.go:116: context deadline exceeded

--- FAIL: kuttl (1582.94s)
    --- FAIL: kuttl/harness (0.00s)
        --- FAIL: kuttl/harness/smoke_hbase-2.4.17_hdfs-3.3.6_zookeeper-3.8.4_listener-class-external-unstable_openshift-false (260.17s)
```

Sometimes, deleting the PersistentVolumeClaims takes more than 2 minutes, so I increased the timeout to 5 minutes.

Successful test runs are not affected by this change. Failed test runs are in most cases not affected, because usually the test steps have explicitly set their timeout:

```yaml
---
apiVersion: kuttl.dev/v1beta1
kind: TestAssert
timeout: 600
```