### PR TITLE
Reinstalling krb5 and protoc on arm to fix some compile issues

### DIFF
--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -363,7 +363,12 @@ jobs:
             echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
             sudo apt-get -y update
             sudo apt-get -y install helm
+            # Fix for secret operator
+            sudo apt-get -y install libkrb5-dev
+            # Fix for secret and listener operator
+            sudo apt-get -y install protobuf-compiler
             sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_arm64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq
+
           fi
 
           make -e build

--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -7,7 +7,7 @@
 # It is available from Nixpkgs as `yq-go` (`nix shell nixpkgs#yq-go`)
 # This script also requires `jq` https://stedolan.github.io/jq/
 
-.PHONY: build publish
+.PHONY: build, publish
 
 TAG    := $(shell git rev-parse --short HEAD)
 OPERATOR_NAME := {[ operator.name }]


### PR DESCRIPTION
Fix for `krb5` and `protoc` for ARM processors. 
Fix: Missing seperator broke pipeline in `Makefile`