### PR TITLE
fix: Assorted lint and ci fixes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-ignore = E111,E501,E114

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -14,6 +14,10 @@ MD013:
   # Number of characters for code blocks
   code_block_line_length: 9999
 
+# MD033/no-inline-html
+MD033:
+  allowed_elements: [h1, img, p]
+
 # MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
 MD024:
   # Only check sibling headings

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,8 @@ repos:
     rev: v1.35.1
     hooks:
       - id: yamllint
+        types: [text]
+        files: \.(yml|yaml)(\.j2)*$
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.40.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,13 @@ repos:
         types: [text]
         files: \.md(\.j2)*$
 
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
+  # WARNING (@NickLarsenNZ): Nix users need to install ruff first.
+  # If you do not, you will need to delete the cached ruff binary shown in the
+  # error message
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.1
     hooks:
-      - id: flake8
+      # Run the linter.
+      - id: ruff
+      # Run the formatter.
+      - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,8 @@ repos:
     rev: v0.40.0
     hooks:
       - id: markdownlint
+        types: [text]
+        files: \.md(\.j2)*$
 
   - repo: https://github.com/PyCQA/flake8
     rev: 7.0.0

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,8 +1,11 @@
 ---
 extends: default
 
-ignore: |
-  template/deploy/helm/**/templates
+ignore:
+  # yamllint can't parse these files as yaml because of j2 templating
+  - template/.github/ISSUE_TEMPLATE/bug_report.yml.j2
+  - template/deploy/helm/\[\[operator\]\]/Chart.yaml.j2
+  - template/deploy/helm/**/templates
 
 rules:
   line-length: disable

--- a/config/retired_files.yaml
+++ b/config/retired_files.yaml
@@ -5,3 +5,4 @@
 retired_files:
   - python/cargo_version.py
   - python/requirements.txt
+  - flake8 # replaced by ruff

--- a/template/.flake8
+++ b/template/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-ignore = E111,E501,E114

--- a/template/.github/ISSUE_TEMPLATE/new_version.md.j2
+++ b/template/.github/ISSUE_TEMPLATE/new_version.md.j2
@@ -7,25 +7,25 @@ assignees: ''
 
 ---
 
-**Which new version of {[ operator.pretty_string }] should we support?**
+## Which new version of {[ operator.pretty_string }] should we support?
 
 Please specify the version, version range or version numbers to support, please also add these to the issue title
 
-**Additional information**
+## Additional information
 
 If possible, provide a link to release notes/changelog
 
-**Changes required**
+## Changes required
 
 Are there any upstream changes that we need to support?
 e.g. new features, changed features, deprecated features etc.
 
+## Implementation checklist
 
-
-**Implementation checklist**
-
-Please don't change anything in this list.
-Not all of these steps are necessary for all versions.
+<!--
+    Please don't change anything in this list.
+    Not all of these steps are necessary for all versions.
+-->
 
 - [ ] Update the Docker image
 - [ ] Update documentation to include supported version(s)

--- a/template/.github/PULL_REQUEST_TEMPLATE/pre-release-getting-started-script.md
+++ b/template/.github/PULL_REQUEST_TEMPLATE/pre-release-getting-started-script.md
@@ -1,4 +1,4 @@
-## Check and Update Getting Started Script
+# Check and Update Getting Started Script
 
 <!--
     Make sure to update the link in 'issues/.github/ISSUE_TEMPLATE/pre-release-getting-started-scripts.md'

--- a/template/.github/PULL_REQUEST_TEMPLATE/pre-release-rust-deps.md
+++ b/template/.github/PULL_REQUEST_TEMPLATE/pre-release-rust-deps.md
@@ -1,4 +1,4 @@
-## Bump Rust Dependencies for Stackable Release XX.(X)X
+# Bump Rust Dependencies for Stackable Release XX.(X)X
 
 <!--
     Make sure to update the link in 'issues/.github/ISSUE_TEMPLATE/pre-release-operator-rust-deps.md'

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -57,7 +57,7 @@ jobs:
           key: udeps
           cache-all-crates: "true"
       - uses: stackabletech/cargo-install-action@cargo-udeps
-      - run: cargo udeps --workspace
+      - run: cargo udeps --workspace --all-targets
 
   # This job evaluates the github environment to determine why this action is running and selects the appropriate
   # target repository for published Helm charts based on this.
@@ -336,13 +336,13 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
           components: rustfmt
+        # This step checks if the current run was triggered by a push to a pr (or a pr being created).
+        # If this is the case it changes the version of this project in all Cargo.toml files to include the suffix
+        # "-pr<prnumber>" so that the published artifacts can be linked to this PR.
       - uses: stackabletech/cargo-install-action@main
         with:
           crate: cargo-edit
           bin: cargo-set-version
-      # This step checks if the current run was triggered by a push to a pr (or a pr being created).
-      # If this is the case it changes the version of this project in all Cargo.toml files to include the suffix
-      # "-pr<prnumber>" so that the published artifacts can be linked to this PR.
       - name: Update version if PR
         if: ${{ github.event_name == 'pull_request' }}
         run: cargo set-version --offline --workspace 0.0.0-pr${{ github.event.pull_request.number }}

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -336,13 +336,13 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
           components: rustfmt
-        # This step checks if the current run was triggered by a push to a pr (or a pr being created).
-        # If this is the case it changes the version of this project in all Cargo.toml files to include the suffix
-        # "-pr<prnumber>" so that the published artifacts can be linked to this PR.
       - uses: stackabletech/cargo-install-action@main
         with:
           crate: cargo-edit
           bin: cargo-set-version
+      # This step checks if the current run was triggered by a push to a pr (or a pr being created).
+      # If this is the case it changes the version of this project in all Cargo.toml files to include the suffix
+      # "-pr<prnumber>" so that the published artifacts can be linked to this PR.
       - name: Update version if PR
         if: ${{ github.event_name == 'pull_request' }}
         run: cargo set-version --offline --workspace 0.0.0-pr${{ github.event.pull_request.number }}

--- a/template/.markdownlint.yaml
+++ b/template/.markdownlint.yaml
@@ -14,6 +14,10 @@ MD013:
   # Number of characters for code blocks
   code_block_line_length: 9999
 
+# MD033/no-inline-html
+MD033:
+  allowed_elements: [h1, img, p]
+
 # MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
 MD024:
   # Only check sibling headings

--- a/template/.pre-commit-config.yaml.j2
+++ b/template/.pre-commit-config.yaml.j2
@@ -32,10 +32,16 @@ repos:
         types: [text]
         files: \.md(\.j2)*$
 
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
+  # WARNING (@NickLarsenNZ): Nix users need to install ruff first.
+  # If you do not, you will need to delete the cached ruff binary shown in the
+  # error message
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.1
     hooks:
-      - id: flake8
+      # Run the linter.
+      - id: ruff
+      # Run the formatter.
+      - id: ruff-format
 
   - repo: local
     hooks:

--- a/template/.pre-commit-config.yaml.j2
+++ b/template/.pre-commit-config.yaml.j2
@@ -29,6 +29,8 @@ repos:
     rev: v0.40.0
     hooks:
       - id: markdownlint
+        types: [text]
+        files: \.md(\.j2)*$
 
   - repo: https://github.com/PyCQA/flake8
     rev: 7.0.0

--- a/template/.pre-commit-config.yaml.j2
+++ b/template/.pre-commit-config.yaml.j2
@@ -1,4 +1,6 @@
 ---
+exclude: ^(Cargo\.nix|crate-hashes\.json|nix/.*)$
+
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
@@ -7,7 +9,6 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-        exclude: ^crate-hashes\.json$
       - id: detect-aws-credentials
         args: ["--allow-missing-credentials"]
       - id: detect-private-key

--- a/template/.pre-commit-config.yaml.j2
+++ b/template/.pre-commit-config.yaml.j2
@@ -7,6 +7,7 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+        exclude: ^crate-hashes\.json$
       - id: detect-aws-credentials
         args: ["--allow-missing-credentials"]
       - id: detect-private-key

--- a/template/.readme/partials/borrowed/documentation.md.j2.j2
+++ b/template/.readme/partials/borrowed/documentation.md.j2.j2
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041 -->
 ## Documentation
 
 The stable documentation for this operator can be found [here](https://docs.stackable.tech/home/stable/{{operator_docs_slug}}).

--- a/template/.readme/partials/borrowed/footer.md.j2.j2
+++ b/template/.readme/partials/borrowed/footer.md.j2.j2
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041 -->
 ## About The Stackable Data Platform
 
 This operator is written and maintained by [Stackable](https://stackable.tech) and it is part of a larger data platform.
@@ -23,7 +24,6 @@ We develop and test our operators on the following cloud platforms:
 * K3s
 * Kubernetes (for an up to date list of supported versions please check the release notes in our [docs](https://docs.stackable.tech))
 * Red Hat OpenShift
-
 
 ## Other Operators
 

--- a/template/.readme/partials/borrowed/header.md.j2.j2
+++ b/template/.readme/partials/borrowed/header.md.j2.j2
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041 -->
 <p align="center">
   <img width="150" src="./.readme/static/borrowed/Icon_Stackable.svg" alt="Stackable Logo"/>
 </p>

--- a/template/.readme/partials/borrowed/links.md.j2.j2
+++ b/template/.readme/partials/borrowed/links.md.j2.j2
@@ -1,4 +1,4 @@
-
+<!-- markdownlint-disable MD041 -->
 {# NOTE: the empty line above is important! -#}
 {% if no_jenkins_job_badge %}{% else %}![Build Actions Status](https://ci.stackable.tech/buildStatus/icon?job={{operator_name}}%2doperator%2dit%2dnightly&subject=Integration%20Tests){% endif %}
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://GitHub.com/stackabletech/{{operator_name}}-operator/graphs/commit-activity)

--- a/template/.readme/partials/borrowed/overview_blurb.md.j2.j2
+++ b/template/.readme/partials/borrowed/overview_blurb.md.j2.j2
@@ -1,1 +1,2 @@
+<!-- markdownlint-disable MD041 MD051 -->
 It is part of the Stackable Data Platform, a curated selection of the best open source data apps like Apache Kafka, Apache Druid, Trino or Apache Spark, [all](#other-operators) working together seamlessly. Based on Kubernetes, it runs everywhere – [on prem or in the cloud](#supported-platforms).

--- a/template/.readme/partials/borrowed/related_reading.md.j2.j2
+++ b/template/.readme/partials/borrowed/related_reading.md.j2.j2
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041 MD022 MD032 -->
 {%- if related_reading_links -%}
 ## Related Reading
 {% for (text, link) in related_reading_links %}

--- a/template/deploy/DO_NOT_EDIT.md.j2
+++ b/template/deploy/DO_NOT_EDIT.md.j2
@@ -1,3 +1,5 @@
+# DO NOT EDIT
+
 These Helm charts and manifests are automatically generated.
 Please do not edit anything except for files explicitly mentioned below in this
 directory manually.

--- a/template/deploy/helm/[[operator]]/README.md.j2
+++ b/template/deploy/helm/[[operator]]/README.md.j2
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD034 -->
 # Helm Chart for Stackable Operator for {[ operator.pretty_string }]
 
 This Helm Chart can be used to install Custom Resource Definitions and the Operator for {[ operator.pretty_string }] provided by Stackable.
@@ -24,4 +25,4 @@ The operator has example requests included in the [`/examples`](https://github.c
 
 ## Links
 
-https://github.com/stackabletech/{[ operator.name }]
+<https://github.com/stackabletech/{[ operator.name }]>

--- a/template/scripts/ensure_one_trailing_newline.py
+++ b/template/scripts/ensure_one_trailing_newline.py
@@ -2,6 +2,7 @@
 Given the location of a file, trims all trailing blank lines and
 places a single one. Used as post-processing step for README rendering.
 """
+
 import re
 import unittest
 
@@ -34,7 +35,6 @@ def process_lines(lines):
 
 
 class TestCoreMethods(unittest.TestCase):
-
     def test_trailing_new_line(self):
         self.assertTrue(has_trailing_newline("something\n"))
         self.assertTrue(has_trailing_newline("\n"))

--- a/template/shell.nix
+++ b/template/shell.nix
@@ -11,6 +11,7 @@ in pkgs.mkShell rec {
   packages = with pkgs; [
     ## cargo et-al
     rustup # this breaks pkg-config if it is in the nativeBuildInputs
+    cargo-udeps
 
     ## Extra dependencies for use in a pure env (nix-shell --pure)
     ## These are mosuly useful for maintainers of this shell.nix


### PR DESCRIPTION
- Enable lints for jinja templates (markdown and yaml)
  - Fix lints
- template: Ignore linting generated files
- template: Run udeps with `--all-targets`
- Replace flake8 with ruff