### PR TITLE
chore: remove unused flake8 checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,12 @@ repos:
         types: [text]
         files: \.md(\.j2)*$
 
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.10.0
+    hooks:
+      - id: shellcheck
+        args: ["--severity=info"]
+
   # WARNING (@NickLarsenNZ): Nix users need to install ruff first.
   # If you do not, you will need to delete the cached ruff binary shown in the
   # error message

--- a/template/.github/workflows/pr_pre-commit.yaml
+++ b/template/.github/workflows/pr_pre-commit.yaml
@@ -1,0 +1,17 @@
+---
+name: pre-commit
+
+on:
+  pull_request:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+        with:
+          python-version: '3.12'
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        with:
+          extra_args: "" # Disable --all-files until we have time to fix druid/stackable/bin/run-druid

--- a/template/.github/workflows/pr_reviewdog.yaml
+++ b/template/.github/workflows/pr_reviewdog.yaml
@@ -23,17 +23,6 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  flake8:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # tag=v5.1.0
-        with:
-          python-version: "3.12"
-      - uses: reviewdog/action-flake8@99c2cfecdbc9111ec223b85b08af0e13a9a098dc # v3.10.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
   hadolint:
     runs-on: ubuntu-latest
     steps:

--- a/template/.pre-commit-config.yaml.j2
+++ b/template/.pre-commit-config.yaml.j2
@@ -33,6 +33,12 @@ repos:
         types: [text]
         files: \.md(\.j2)*$
 
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.10.0
+    hooks:
+      - id: shellcheck
+        args: ["--severity=info"]
+
   # WARNING (@NickLarsenNZ): Nix users need to install ruff first.
   # If you do not, you will need to delete the cached ruff binary shown in the
   # error message

--- a/template/scripts/run_tests.sh
+++ b/template/scripts/run_tests.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-./scripts/run-tests $@
+./scripts/run-tests "$@"


### PR DESCRIPTION
- Remove flake8 from reviewdog checks (replaced by ruff in pre-commit checks below)
- Add pre-commit checks for PRs
  - add shellcheck
- Resolve shellcheck warnings on script