### PR TITLE
fix(ci): Install hadolint in pre-commit workflow

### DIFF
--- a/.github/workflows/pr_pre-commit.yml
+++ b/.github/workflows/pr_pre-commit.yml
@@ -7,6 +7,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_TOOLCHAIN_VERSION: "1.80.1"
+  HADOLINT_VERSION: "v1.17.6"
 
 jobs:
   pre-commit:
@@ -22,6 +23,22 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
           components: rustfmt,clippy
+      - name: Setup Hadolint
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          LOCATION_DIR="$HOME/.local/bin"
+          LOCATION_BIN="$LOCATION_DIR/hadolint"
+
+          SYSTEM=$(uname -s)
+          ARCH=$(uname -m)
+
+          mkdir -p "$LOCATION_DIR"
+          curl -sL -o "${LOCATION_BIN}" "https://github.com/hadolint/hadolint/releases/download/${{ env.HADOLINT_VERSION }}/hadolint-$SYSTEM-$ARCH"
+          chmod 700 "${LOCATION_BIN}"
+
+          echo "$LOCATION_DIR" >> "$GITHUB_PATH"
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: "--from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,9 @@
 ---
 fail_fast: false
 
+default_language_version:
+  node: system
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c # 4.6.0

--- a/config/rust.yaml
+++ b/config/rust.yaml
@@ -3,3 +3,4 @@
 # If you change the Rust toolchain version here, make sure to also change
 # docker-images/ubi8-rust-builder/Dockerfile & docker-images/ubi9-rust-builder/Dockerfile
 rust_version: 1.80.0
+hadolint_version: v1.17.6

--- a/template/.github/workflows/pr_pre-commit.yaml.j2
+++ b/template/.github/workflows/pr_pre-commit.yaml.j2
@@ -7,6 +7,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_TOOLCHAIN_VERSION: "{[ rust_version }]"
+  HADOLINT_VERSION: "{[ hadolint_version }]"
 
 jobs:
   pre-commit:
@@ -22,6 +23,22 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
           components: rustfmt,clippy
+      - name: Setup Hadolint
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          LOCATION_DIR="$HOME/.local/bin"
+          LOCATION_BIN="$LOCATION_DIR/hadolint"
+
+          SYSTEM=$(uname -s)
+          ARCH=$(uname -m)
+
+          mkdir -p "$LOCATION_DIR"
+          curl -sL -o "${LOCATION_BIN}" "https://github.com/hadolint/hadolint/releases/download/${{ env.HADOLINT_VERSION }}/hadolint-$SYSTEM-$ARCH"
+          chmod 700 "${LOCATION_BIN}"
+
+          echo "$LOCATION_DIR" >> "$GITHUB_PATH"
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
           extra_args: "--from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}"

--- a/template/.pre-commit-config.yaml.j2
+++ b/template/.pre-commit-config.yaml.j2
@@ -1,6 +1,9 @@
 ---
 exclude: ^(Cargo\.nix|crate-hashes\.json|nix/.*)$
 
+default_language_version:
+  node: system
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: 2c9f875913ee60ca25ce70243dc24d5b6415598c # 4.6.0


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/637

This fixes two things:

- Install the hadolint binary to be able to run the pre-commit hook
- Set the default language version of `node` to `system`. This fixes issues on NixOS systems.