### PR TITLE
Configure renovate so that it should be able to pick up pre-commit

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,8 @@
   ],
   "github-actions": {
     "fileMatch": ["(^template\\/\\.github\\/workflows)\\/[^/]+\\.ya?ml(.j2)?$"]
+  },
+  "pre-commit": {
+    "fileMatch": ["(^|/)\\.pre-commit-config\\.ya?ml(.j2)$"]
   }
 }


### PR DESCRIPTION
`pre-commit` support is at the moment only in beta test for renovate so it has to be enabled manually in the config for renovate. I'll do that separately.

https://docs.renovatebot.com/modules/manager/pre-commit/