### PR TITLE
ci(pre-commit): Ignore j2 files for hadolint hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,4 @@ repos:
     rev: b3555ba9c2bfd9401e79f2f0da68dd1ae38e10c7 # 2.12.0
     hooks:
       - id: hadolint
+        exclude: \.j2$

--- a/template/docker/Dockerfile.j2
+++ b/template/docker/Dockerfile.j2
@@ -101,9 +101,10 @@ EOF
 COPY LICENSE /licenses/LICENSE
 
 COPY --from=builder /app/* /usr/local/bin/
-# {[% if operator.include_productconfig is undefined or operator.include_productconfig == true %}]
+
+{[% if operator.include_productconfig is undefined or operator.include_productconfig == true %}]
 COPY deploy/config-spec/properties.yaml /etc/stackable/{[operator.name}]/config-spec/properties.yaml
-# {[% endif %}]
+{[% endif %}]
 
 USER ${STACKABLE_USER_UID}
 

--- a/template/docker/Dockerfile.j2
+++ b/template/docker/Dockerfile.j2
@@ -103,7 +103,7 @@ COPY LICENSE /licenses/LICENSE
 COPY --from=builder /app/* /usr/local/bin/
 
 {[% if operator.include_productconfig is undefined or operator.include_productconfig == true %}]
-COPY deploy/config-spec/properties.yaml /etc/stackable/{[operator.name}]/config-spec/properties.yaml
+COPY deploy/config-spec/properties.yaml /etc/stackable/{[ operator.name }]/config-spec/properties.yaml
 {[% endif %}]
 
 USER ${STACKABLE_USER_UID}


### PR DESCRIPTION
Ansible enables whitespace trimming for j2 template blocks, which means the `COPY` command was being hoisted into the comment on the line above.

The comment was only added so that hadolint would be able to parse the Dockerfile.

We've chosen to ignore j2 files rather than disable the trimming, as that could lead to other unknown problems across many files (with the least of the problems being new lint failures).

This does mean that formatting problems will only be picked up in PRs on the operators after templating, and fixes will need pulling back into operator-templating.