### PR TITLE
Fix broken Dockerfile and minor improvements

### DIFF
--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -265,7 +265,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
         with:
-          version: v3.13.3
+          version: v3.16.1
       - name: Set up cargo
         uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a
         with:
@@ -310,6 +310,7 @@ jobs:
       matrix:
         runner: ["ubuntu-latest", "ubicloud-standard-8-arm"]
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
     permissions:
       id-token: write
     env:

--- a/template/docker/Dockerfile.j2
+++ b/template/docker/Dockerfile.j2
@@ -66,23 +66,55 @@ LABEL io.openshift.tags="ubi9,stackable,sdp,{[ operator.product_string }]"
 LABEL io.k8s.description="Deploy and manage {[ operator.pretty_string }] clusters."
 LABEL io.k8s.display-name="Stackable Operator for {[ operator.pretty_string }]"
 
+COPY <<EOF /etc/dnf/dnf.conf
+[main]
+install_weak_deps=0
+assumeyes=True
+tsflags=nodocs
+EOF
+
 RUN <<EOF
-# Update image and install kerberos client libraries
-# install_weak_deps in microdnf does not support the literal "False" as dnf does
-# https://github.com/rpm-software-management/microdnf/blob/a600c62f29262d71a6259b70dc220df65a2ab9b5/dnf/dnf-main.c#L176-L189
+# Update image and install kerberos client libraries as well as some other utilities
 microdnf update
+
+# **iputils**
+# To make debugging easier, includes things like ping
+# Added 2024-03: We cannot find any vulnerabilities in the past years
+# https://github.com/iputils/iputils
+#
+# **less**
+# To make debugging easier
+# Added 2024-03: less has seen three vulnerabilities between 2004 and 2022 which is a risk we're willing to accept for the added convenience
+# https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&search_type=all&isCpeNameSearch=false&cpe_vendor=cpe%3A%2F%3Agnu&cpe_product=cpe%3A%2F%3A%3Aless
+# cpe:2.3:a:gnu:less:*:*:*:*:*:*:*:*
+#
+# **nano**
+# To make debugging and changing things easier
+# Added 2024-03: We checked and it has not seen any vulnerabilities since 2010 (as of 2024-03) we decided to accept it into our base image
+# https://nvd.nist.gov/vuln/search/results?form_type=Advanced&results_type=overview&query=cpe%3A2.3%3Aa%3Agnu%3Anano&search_type=all&isCpeNameSearch=false
+# cpe:2.3:a:gnu:nano:*:*:*:*:*:*:*:*
+#
+# **tar**
+# To enable kubectl cp
+# Added 2024-03: We checked and it has seen eight vulnerabilities since 2001, mostly minor and it's not in executable path so we decided to accept the risk
+# https://nvd.nist.gov/vuln/search/results?adv_search=true&isCpeNameSearch=true&query=cpe%3A2.3%3Aa%3Agnu%3Atar%3A-%3A*%3A*%3A*%3A*%3A*%3A*%3A*
+# cpe:2.3:a:gnu:tar:-:*:*:*:*:*:*:*
 # NOTE (@NickLarsenNZ): Maybe we should consider pinning package versions?
 # hadolint ignore=DL3041
-microdnf install -y \
+microdnf install \
+  iputils \
   krb5-libs \
+  less \
   libkadm5 \
-  shadow-utils
+  nano \
+  shadow-utils \
+  tar
 
-groupadd --gid ${STACKABLE_USER_GID} --system ${STACKABLE_USER_NAME}
+groupadd --gid ${STACKABLE_USER_GID} --system stackable
 # The --no-log-init is required to work around a bug/problem in Go/Docker when very large UIDs are used
 # See https://github.com/moby/moby/issues/5419#issuecomment-41478290 for more context
 # Making this a system user prevents a mail dir from being created, expiry of passwords etc. but it will warn:
-#   useradd warning: stackable's uid 1000 is greater than SYS_UID_MAX 999
+#   useradd warning: stackable's uid 782252253 is greater than SYS_UID_MAX 999
 # We can safely ignore this warning, to get rid of the warning we could change /etc/login.defs but that does not seem worth it
 # We'll leave the home directory hardcoded to /stackable because I don't want to deal with which chars might be valid and which might not in user name vs. directory
 useradd \
@@ -96,6 +128,21 @@ useradd \
 microdnf remove shadow-utils
 microdnf clean all
 rm -rf /var/cache/yum
+
+###
+### Make shell usage in our containers "nicer"
+###
+{
+  echo "alias ll='ls -alF --color=auto'"
+  echo "alias ls='ls --color=auto'"
+  echo "alias ..='cd ..'"
+  echo "export PS1='\u@\[\e[36m\]\H\[\e[m\] \[\e[32m\]\$(pwd)\[\e[m\] \\$ '"
+} >> /stackable/.bashrc
+
+echo -e "if [ -f ~/.bashrc ]; then\n\tsource ~/.bashrc\nfi" >> /stackable/.profile
+
+chown ${STACKABLE_USER_UID}:0 /stackable/.bashrc
+chown ${STACKABLE_USER_UID}:0 /stackable/.profile
 EOF
 
 COPY LICENSE /licenses/LICENSE

--- a/template/docker/Dockerfile.j2
+++ b/template/docker/Dockerfile.j2
@@ -143,11 +143,25 @@ echo -e "if [ -f ~/.bashrc ]; then\n\tsource ~/.bashrc\nfi" >> /stackable/.profi
 
 chown ${STACKABLE_USER_UID}:0 /stackable/.bashrc
 chown ${STACKABLE_USER_UID}:0 /stackable/.profile
+
+# All files and folders owned by root to support running as arbitrary users
+# This is best practice as all container users will belong to the root group (0)
+# This is not very relevant for the operator images but this makes it consistent with `docker-images`
+chown -R ${STACKABLE_USER_UID}:0 /stackable
+chmod -R g=u /stackable
+EOF
+
+COPY <<EOF /README.md
+# Stackable Operator for {[ operator.pretty_string }]
+
+* This image contains version ${VERSION} of the operator.
+* The operator binary can be found in `/usr/local/bin`
+* It is licensed under the OSL-3.0 - the full text can be found in `/licenses/LICENSE`
 EOF
 
 COPY LICENSE /licenses/LICENSE
 
-COPY --from=builder /app/* /usr/local/bin/
+COPY --from=builder --chown=${STACKABLE_USER_UID}:0 /app/* /usr/local/bin/
 
 {[% if operator.include_productconfig is undefined or operator.include_productconfig == true %}]
 COPY deploy/config-spec/properties.yaml /etc/stackable/{[ operator.name }]/config-spec/properties.yaml


### PR DESCRIPTION
This fixes an issue introduced by a past PR (https://github.com/stackabletech/operator-templating/pull/432). It uses an argument that doesn't exist ("STACKABLE_USER_NAME").

In the course of diagnosing that I stumbled across a few inconsistencies with our "docker-images" Dockerfiles which I am addressing here as well.

- Updates the Helm version used (not caught by Renovate yet)
- Sets a build timeout for the build & package phase to two hours (down from the default of 6)
- Adds the dnf.conf file
- Adds convenience utilities
- Adds a few common aliases and a better prompt