### PR TITLE
ci(template): Ignore build for doc changes

### DIFF
--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -14,7 +14,13 @@ on:
       - "renovate/**"
     tags:
       - '[0-9][0-9].[0-9]+.[0-9]+'
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
   pull_request:
+    paths-ignore:
+      - '*.md'
+      - 'docs/**'
   merge_group:
   schedule:
     # Run every Saturday morning: https://crontab.guru/#15_3_*_*_6


### PR DESCRIPTION
It makes little sense to build everything if only docs have changed.

> [!CAUTION]
> Need to check if the "Stackable Build Pipeline" is a required check in Github Repo Settings. Would a PR with the build job skipped be allowed to merge?