### PR TITLE
ci: Use stackabletech/actions repo

### DIFF
--- a/.github/workflows/pr_pre-commit.yml
+++ b/.github/workflows/pr_pre-commit.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
-      - uses: stackabletech/actions/run-pre-commit@93b2a5a023487ef9509f24600c12374553478f1d # 0.0.1
+      - uses: stackabletech/actions/run-pre-commit@e8781161bc1eb037198098334cec6061fe24b6c3 # v0.0.2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           hadolint: ${{ env.HADOLINT_VERSION }}

--- a/.github/workflows/pr_pre-commit.yml
+++ b/.github/workflows/pr_pre-commit.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   HADOLINT_VERSION: "v2.12.0"
+  PYTHON_VERSION: "3.12"
 
 jobs:
   pre-commit:
@@ -14,27 +15,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
+      - uses: stackabletech/actions/run-pre-commit@93b2a5a023487ef9509f24600c12374553478f1d # 0.0.1
         with:
-          python-version: '3.12'
-      - name: Setup Hadolint
-        # We need to download this here due to a bug in the pre-commit/hadolint setup
-        # https://github.com/hadolint/hadolint/issues/886
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          LOCATION_DIR="$HOME/.local/bin"
-          LOCATION_BIN="$LOCATION_DIR/hadolint"
-
-          SYSTEM=$(uname -s)
-          ARCH=$(uname -m)
-
-          mkdir -p "$LOCATION_DIR"
-          curl -sL -o "${LOCATION_BIN}" "https://github.com/hadolint/hadolint/releases/download/${{ env.HADOLINT_VERSION }}/hadolint-$SYSTEM-$ARCH"
-          chmod 700 "${LOCATION_BIN}"
-
-          echo "$LOCATION_DIR" >> "$GITHUB_PATH"
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-        with:
-          extra_args: "--from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}"
+          python-version: ${{ env.PYTHON_VERSION }}
+          hadolint: ${{ env.HADOLINT_VERSION }}

--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -6,6 +6,11 @@ rust_version: 1.80.1
 
 # IMPORTANT
 # If you change the Hadolint version here, make sure to also change the hook
-# refs in the local and template .pre-commit-config.yaml files.
+# refs in the local and templated .pre-commit-config.yaml files.
 # And due to a bug you also need to update the version in .github/workflows/pr_pre_commit.yml
 hadolint_version: v2.12.0
+
+# IMPORTANT
+# If you change the Python version here, make sure to also change it in
+# .github/workflows/pr_pre-commit.yml
+python_version: 3.12

--- a/template/.github/workflows/pr_pre-commit.yaml.j2
+++ b/template/.github/workflows/pr_pre-commit.yaml.j2
@@ -8,6 +8,7 @@ env:
   CARGO_TERM_COLOR: always
   RUST_TOOLCHAIN_VERSION: "{[ rust_version }]"
   HADOLINT_VERSION: "{[ hadolint_version }]"
+  PYTHON_VERSION: "{[ python_version }]"
 
 jobs:
   pre-commit:
@@ -22,29 +23,8 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-      - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
+      - uses: stackabletech/actions/run-pre-commit@93b2a5a023487ef9509f24600c12374553478f1d # 0.0.1
         with:
-          python-version: '3.12'
-      - uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
-          components: rustfmt,clippy
-      - name: Setup Hadolint
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          LOCATION_DIR="$HOME/.local/bin"
-          LOCATION_BIN="$LOCATION_DIR/hadolint"
-
-          SYSTEM=$(uname -s)
-          ARCH=$(uname -m)
-
-          mkdir -p "$LOCATION_DIR"
-          curl -sL -o "${LOCATION_BIN}" "https://github.com/hadolint/hadolint/releases/download/${{ env.HADOLINT_VERSION }}/hadolint-$SYSTEM-$ARCH"
-          chmod 700 "${LOCATION_BIN}"
-
-          echo "$LOCATION_DIR" >> "$GITHUB_PATH"
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-        with:
-          extra_args: "--from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}"
+          python-version: ${{ env.PYTHON_VERSION }}
+          rust: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          hadolint: ${{ env.HADOLINT_VERSION }}

--- a/template/.github/workflows/pr_pre-commit.yaml.j2
+++ b/template/.github/workflows/pr_pre-commit.yaml.j2
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-      - uses: stackabletech/actions/run-pre-commit@93b2a5a023487ef9509f24600c12374553478f1d # 0.0.1
+      - uses: stackabletech/actions/run-pre-commit@e8781161bc1eb037198098334cec6061fe24b6c3 # v0.0.2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           rust: ${{ env.RUST_TOOLCHAIN_VERSION }}


### PR DESCRIPTION
This PR updates all workflows to use the https://github.com/stackabletech/actions repo instead of local actions.