### PR TITLE
chore: Migrate pre-commit config

### DIFF
--- a/template/.pre-commit-config.yaml.j2
+++ b/template/.pre-commit-config.yaml.j2
@@ -67,12 +67,12 @@ repos:
         name: regenerate-charts
         language: system
         entry: make regenerate-charts
-        stages: [commit, merge-commit, manual]
+        stages: [pre-commit, pre-merge-commit, manual]
         pass_filenames: false
 
       - id: cargo-test
         name: cargo-test
         language: system
         entry: cargo test
-        stages: [commit, merge-commit, manual]
+        stages: [pre-commit, pre-merge-commit, manual]
         pass_filenames: false


### PR DESCRIPTION
Note: This requires pre-commit version 4.0.0 or later. Earlier versions will fail on the new stage names.