### PR TITLE
Rename KUBERNETES_CLUSTER_DOMAIN to KUBERNETES_CLUSTER_DOMAIN

### DIFF
--- a/template/deploy/helm/[[operator]]/templates/deployment.yaml.j2
+++ b/template/deploy/helm/[[operator]]/templates/deployment.yaml.j2
@@ -48,8 +48,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.annotations['internal.stackable.tech/image']
-            - name: KUBERNETES_SERVICE_DNS_DOMAIN
-              value: {{ .Values.kubernetesServiceDnsDomain | default "cluster.local" | quote }}
+            - name: KUBERNETES_CLUSTER_DOMAIN
+              value: {{ .Values.kubernetesClusterDomain | default "cluster.local" | quote }}
 {[% if operator.product_string in ['kafka'] %}]
             - name: KAFKA_BROKER_CLUSTERROLE
               value: {{ include "operator.fullname" . }}-kafka-broker-clusterrole


### PR DESCRIPTION
Not breaking, as this was added hours ago in https://github.com/stackabletech/operator-templating/pull/445, so no one actually uses it