### PR TITLE
fix: Skip the build/publish manifest list job on forks

### DIFF
--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -384,6 +384,7 @@ jobs:
 
   create_manifest_list:
     name: Build and publish manifest list
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     needs:
       - package_and_publish
     runs-on: ubuntu-latest


### PR DESCRIPTION
Continuation of: https://github.com/stackabletech/operator-templating/pull/336