### PR TITLE
chore: temporary disable integration tests

### DIFF
--- a/template/.github/workflows/integration-test.yml
+++ b/template/.github/workflows/integration-test.yml
@@ -14,9 +14,9 @@ env:
   TEST_PARAMETER: ${{ inputs.test-parameter }}
 
 on:
-  schedule:
+  # schedule:
     # At 00:00 on Sunday. See: https://crontab.guru/#0_0_*_*_0
-    - cron: "0 0 * * 0"
+    # - cron: "0 0 * * 0"
   workflow_dispatch:
     inputs:
       test-platform:


### PR DESCRIPTION
Disabled for now to allow merging the latest change (SBOM fix) with downstream PRs into the operator repos, will enable them after the release