### PR TITLE
chore: Allow OpenSSL license (needed for ring and aws-lc-sys crates)

### DIFF
--- a/template/deny.toml
+++ b/template/deny.toml
@@ -26,6 +26,7 @@ allow = [
     "LicenseRef-webpki",
     "MIT",
     "MPL-2.0",
+    "OpenSSL", # Needed for the aws-lc-sys crate
     "Unicode-3.0",
     "Unicode-DFS-2016",
     "Zlib",

--- a/template/deny.toml
+++ b/template/deny.toml
@@ -26,7 +26,7 @@ allow = [
     "LicenseRef-webpki",
     "MIT",
     "MPL-2.0",
-    "OpenSSL", # Needed for the aws-lc-sys crate
+    "OpenSSL", # Needed for the ring and/or aws-lc-sys crate. See https://github.com/stackabletech/operator-templating/pull/464 for details
     "Unicode-3.0",
     "Unicode-DFS-2016",
     "Zlib",


### PR DESCRIPTION
Came up in https://github.com/stackabletech/operator-rs/pull/907#discussion_r1848217771

```
error[rejected]: failed to satisfy license requirements
  ┌─ registry+https://github.com/rust-lang/crates.io-index#aws-lc-sys@0.22.0:4:44
  │
4 │ license = "ISC AND (Apache-2.0 OR ISC) AND OpenSSL"
  │            ────────────────────────────────━━━━━━━
  │            │                               │
  │            │                               rejected: license is not explicitly allowed
  │            license expression retrieved via Cargo.toml `license`
  │
  ├ OpenSSL - OpenSSL License:
  ├   - FSF Free/Libre
  ├ aws-lc-sys v0.22.0
    └── aws-lc-rs v1.10.0
        ├── rustls v0.23.15
        │   ├── hyper-rustls v0.27.3
        │   │   └── kube-client v0.96.0
        │   │       ├── kube v0.96.0
        │   │       │   ├── stackable-certs v0.3.1
        │   │       │   │   └── stackable-webhook v0.3.1
        │   │       │   │       └── (dev) stackable-telemetry v0.2.0
        │   │       │   │           └── stackable-webhook v0.3.1 (*)
        │   │       │   ├── stackable-operator v0.81.0
        │   │       │   │   ├── stackable-certs v0.3.1 (*)
        │   │       │   │   ├── (dev) stackable-operator-derive v0.3.1
        │   │       │   │   │   └── stackable-operator v0.81.0 (*)
        │   │       │   │   └── stackable-webhook v0.3.1 (*)
        │   │       │   ├── stackable-shared v0.0.1
        │   │       │   │   ├── stackable-operator v0.81.0 (*)
        │   │       │   │   ├── stackable-versioned v0.4.1
        │   │       │   │   │   └── (dev) stackable-versioned-macros v0.4.1
        │   │       │   │   │       └── stackable-versioned v0.4.1 (*)
        │   │       │   │   └── stackable-versioned-macros v0.4.1 (*)
        │   │       │   ├── stackable-versioned v0.4.1 (*)
        │   │       │   ├── stackable-versioned-macros v0.4.1 (*)
        │   │       │   └── stackable-webhook v0.3.1 (*)
        │   │       └── kube-runtime v0.96.0
        │   │           └── kube v0.96.0 (*)
        │   ├── kube-client v0.96.0 (*)
        │   └── tokio-rustls v0.26.0
        │       ├── hyper-rustls v0.27.3 (*)
        │       ├── stackable-certs v0.3.1 (*)
        │       └── stackable-webhook v0.3.1 (*)
        └── rustls-webpki v0.102.8
            └── rustls v0.23.15 (*)
```