### PR TITLE
fix: Exit with error when jinja2 is not found

### DIFF
--- a/template/scripts/docs_templating.sh
+++ b/template/scripts/docs_templating.sh
@@ -21,7 +21,7 @@ fi
 if ! command -v jinja2 &> /dev/null
 then
   echo "jinja2 could not be found. Use 'pip install jinja2-cli' to install it."
-  exit
+  exit 1
 fi
 
 # Check if templating vars file exists


### PR DESCRIPTION
The scripts was silently failing for people who don't have `jinja2`, and the error was hidden among a lot of bash debug output from the stackable-utils release scripts.