### PR TITLE
chore: Bump Rust toolchain to 1.82.0

### DIFF
--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -2,7 +2,7 @@
 # IMPORTANT
 # If you change the Rust toolchain version here, make sure to also change
 # docker-images/ubi8-rust-builder/Dockerfile & docker-images/ubi9-rust-builder/Dockerfile
-rust_version: 1.81.0
+rust_version: 1.82.0
 
 # IMPORTANT
 # If you change the Hadolint version here, make sure to also change the hook


### PR DESCRIPTION
This bumps the Rust toolchain to 1.82.0.