### PR TITLE
ci: Workflow changes in preparation for release-candidates

### DIFF
--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -13,7 +13,7 @@ on:
       - trying
       - "renovate/**"
     tags:
-      - '[0-9][0-9].[0-9]+.[0-9]+'
+      - '[0-9][0-9].[0-9]+.[0-9]+(-rc[0-9]+)?'
   pull_request:
   merge_group:
   schedule:
@@ -345,7 +345,8 @@ jobs:
           crate: cargo-edit
           bin: cargo-set-version
       - name: Update version if PR
-        if: ${{ github.event_name == 'pull_request' }}
+        # For PRs to be merged against a release branch, the version has already been set, in which case ignore this step.
+        if: ${{ github.event_name == 'pull_request' && github.ref == 'refs/heads/main' }}
         run: cargo set-version --offline --workspace 0.0.0-pr${{ github.event.pull_request.number }}
 
       # Recreate charts and publish charts and docker image. The "-e" is needed as we want to override the
@@ -411,7 +412,8 @@ jobs:
           crate: cargo-edit
           bin: cargo-set-version
       - name: Update version if PR
-        if: ${{ github.event_name == 'pull_request' }}
+        # For PRs to be merged against a release branch, the version has already been set, in which case ignore this step.
+        if: ${{ github.event_name == 'pull_request' && github.ref == 'refs/heads/main' }}
         run: cargo set-version --offline --workspace 0.0.0-pr${{ github.event.pull_request.number }}
       - name: Build manifest list
         run: |


### PR DESCRIPTION
See https://github.com/stackabletech/stackable-utils/pull/95/files

This PR:

- extends the tag regex to allow optional `-rcXX` suffixes
- suppresses the automatic setting of the version when merging a PR to a branch other than `main`. The version should be set in the PR creation (e.g. using stackable-utils): if this is not done then an error ocurs in the workflow e.g. `Cannot downgrade from 24.11.1-rc1 to 0.0.0-pr550`