### PR TITLE
ci: set PR-suffix on PRs against non-main/release branches

### DIFF
--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -344,10 +344,15 @@ jobs:
         with:
           crate: cargo-edit
           bin: cargo-set-version
-      - name: Update version if PR
-        # For PRs to be merged against a release branch, the version has already been set, in which case ignore this step.
+      - name: Update version if PR against main branch
         if: ${{ github.event_name == 'pull_request' && github.ref == 'refs/heads/main' }}
         run: cargo set-version --offline --workspace 0.0.0-pr${{ github.event.pull_request.number }}
+      - name: Update version if PR against non-main branch
+        if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/main' }}
+        run: |
+          MANIFEST_VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[0].version')
+          PR_VERSION="${MANIFEST_VERSION}-pr${{ github.event.pull_request.number }}"
+          cargo set-version --offline --workspace "$PR_VERSION"
 
       # Recreate charts and publish charts and docker image. The "-e" is needed as we want to override the
       # default value in the makefile if called from this action, but not otherwise (i.e. when called locally).
@@ -411,10 +416,15 @@ jobs:
         with:
           crate: cargo-edit
           bin: cargo-set-version
-      - name: Update version if PR
-        # For PRs to be merged against a release branch, the version has already been set, in which case ignore this step.
+      - name: Update version if PR against main branch
         if: ${{ github.event_name == 'pull_request' && github.ref == 'refs/heads/main' }}
         run: cargo set-version --offline --workspace 0.0.0-pr${{ github.event.pull_request.number }}
+      - name: Update version if PR against non-main branch
+        if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/main' }}
+        run: |
+          MANIFEST_VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[0].version')
+          PR_VERSION="${MANIFEST_VERSION}-pr${{ github.event.pull_request.number }}"
+          cargo set-version --offline --workspace "$PR_VERSION"
       - name: Build manifest list
         run: |
           # Creating manifest list

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -348,6 +348,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && github.ref == 'refs/heads/main' }}
         run: cargo set-version --offline --workspace 0.0.0-pr${{ github.event.pull_request.number }}
       - name: Update version if PR against non-main branch
+        # For PRs to be merged against a release branch, use the version that has already been set in the calling script.
         if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/main' }}
         run: |
           MANIFEST_VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[0].version')
@@ -420,6 +421,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && github.ref == 'refs/heads/main' }}
         run: cargo set-version --offline --workspace 0.0.0-pr${{ github.event.pull_request.number }}
       - name: Update version if PR against non-main branch
+        # For PRs to be merged against a release branch, use the version that has already been set in the calling script.
         if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/main' }}
         run: |
           MANIFEST_VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[0].version')

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -350,9 +350,11 @@ jobs:
       - name: Update version if PR against non-main branch
         # For PRs to be merged against a release branch, use the version that has already been set in the calling script.
         if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/main' }}
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           MANIFEST_VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[0].version')
-          PR_VERSION="${MANIFEST_VERSION}-pr${{ github.event.pull_request.number }}"
+          PR_VERSION="${MANIFEST_VERSION}-pr${PR_NUMBER}"
           cargo set-version --offline --workspace "$PR_VERSION"
 
       # Recreate charts and publish charts and docker image. The "-e" is needed as we want to override the

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -423,9 +423,11 @@ jobs:
       - name: Update version if PR against non-main branch
         # For PRs to be merged against a release branch, use the version that has already been set in the calling script.
         if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/main' }}
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           MANIFEST_VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[0].version')
-          PR_VERSION="${MANIFEST_VERSION}-pr${{ github.event.pull_request.number }}"
+          PR_VERSION="${MANIFEST_VERSION}-pr${PR_NUMBER}"
           cargo set-version --offline --workspace "$PR_VERSION"
       - name: Build manifest list
         run: |


### PR DESCRIPTION
See stackabletech/stackable-utils#95 (files)

This PR:

- ensures that PRs against non-main (release) branches also incorporate the PR-number into the image name, so that images from a not-yet-merged release-candidate PR have a name distinct from the merged result
- e.g. `24.11.1-rc1-pr554` (unmerged PR branch) vs. `24.11.1-rc1` (merged and tagged in the rlease branch)