### PR TITLE
fix: PR base branch condition

### DIFF
--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -347,7 +347,9 @@ jobs:
           bin: cargo-set-version
       - name: Update version if PR against main branch
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' }}
-        run: cargo set-version --offline --workspace 0.0.0-pr${{ github.event.pull_request.number }}
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: cargo set-version --offline --workspace 0.0.0-pr${PR_NUMBER}
       - name: Update version if PR against non-main branch
         # For PRs to be merged against a release branch, use the version that has already been set in the calling script.
         if: ${{ github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'release-') }}
@@ -422,7 +424,9 @@ jobs:
           bin: cargo-set-version
       - name: Update version if PR against main branch
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' }}
-        run: cargo set-version --offline --workspace 0.0.0-pr${{ github.event.pull_request.number }}
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: cargo set-version --offline --workspace 0.0.0-pr${PR_NUMBER}
       - name: Update version if PR against non-main branch
         # For PRs to be merged against a release branch, use the version that has already been set in the calling script.
         if: ${{ github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'release-') }}

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -346,11 +346,11 @@ jobs:
           crate: cargo-edit
           bin: cargo-set-version
       - name: Update version if PR against main branch
-        if: ${{ github.event_name == 'pull_request' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' }}
         run: cargo set-version --offline --workspace 0.0.0-pr${{ github.event.pull_request.number }}
       - name: Update version if PR against non-main branch
         # For PRs to be merged against a release branch, use the version that has already been set in the calling script.
-        if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/main' }}
+        if: ${{ github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'release-') }}
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
@@ -421,11 +421,11 @@ jobs:
           crate: cargo-edit
           bin: cargo-set-version
       - name: Update version if PR against main branch
-        if: ${{ github.event_name == 'pull_request' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' }}
         run: cargo set-version --offline --workspace 0.0.0-pr${{ github.event.pull_request.number }}
       - name: Update version if PR against non-main branch
         # For PRs to be merged against a release branch, use the version that has already been set in the calling script.
-        if: ${{ github.event_name == 'pull_request' && github.ref != 'refs/heads/main' }}
+        if: ${{ github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'release-') }}
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -349,7 +349,9 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' }}
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: cargo set-version --offline --workspace 0.0.0-pr${PR_NUMBER}
+        run: |
+          PR_VERSION="0.0.0-pr${PR_NUMBER}"
+          cargo set-version --offline --workspace "$PR_VERSION"
       - name: Update version if PR against non-main branch
         # For PRs to be merged against a release branch, use the version that has already been set in the calling script.
         if: ${{ github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'release-') }}
@@ -426,7 +428,9 @@ jobs:
         if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' }}
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: cargo set-version --offline --workspace 0.0.0-pr${PR_NUMBER}
+        run: |
+          PR_VERSION="0.0.0-pr${PR_NUMBER}"
+          cargo set-version --offline --workspace "$PR_VERSION"
       - name: Update version if PR against non-main branch
         # For PRs to be merged against a release branch, use the version that has already been set in the calling script.
         if: ${{ github.event_name == 'pull_request' && startsWith(github.event.pull_request.base.ref, 'release-') }}


### PR DESCRIPTION
Fixes an error in the workflow condition to determine the base branch of a pull-request.

Tested:
- release-branch [PR](https://github.com/stackabletech/airflow-operator/pull/558) built [here](https://github.com/stackabletech/airflow-operator/actions/runs/12260962828/job/34206937064?pr=558)
- main-branch [PR](https://github.com/stackabletech/opa-operator/pull/666) built [here](https://github.com/stackabletech/opa-operator/actions/runs/12260179742/job/34204371351)