### PR TITLE
chore: set defaults to oci

### DIFF
--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -89,7 +89,7 @@ docker-publish:
 	# Attest the SBOM to the image\
 	cosign attest -y --predicate sbom.merged.json --type cyclonedx "${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}@$$REPO_DIGEST_OF_IMAGE"
 
-# This assumes "${DOCKER_REPO}/${ORGANIZATION}/${OPERATOR_NAME}:${VERSION}-amd64 and "${DOCKER_REPO}/${ORGANIZATION}/${OPERATOR_NAME}:${VERSION}-arm64 are build and pushed
+# This assumes "${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}:${VERSION}-amd64 and "${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}:${VERSION}-arm64 are built and pushed
 docker-manifest-list-build:
 	docker manifest create "${DOCKER_REPO}/${ORGANIZATION}/${OPERATOR_NAME}:${VERSION}" --amend "${DOCKER_REPO}/${ORGANIZATION}/${OPERATOR_NAME}:${VERSION}-amd64" --amend "${DOCKER_REPO}/${ORGANIZATION}/${OPERATOR_NAME}:${VERSION}-arm64"
 	docker manifest create "${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}:${VERSION}" --amend "${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}:${VERSION}-amd64" --amend "${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}:${VERSION}-arm64"
@@ -119,7 +119,7 @@ docker-manifest-list-publish:
 docker: docker-build docker-publish
 
 print-docker-tag:
-	@echo "${DOCKER_REPO}/${ORGANIZATION}/${OPERATOR_NAME}:${VERSION}"
+	@echo "${OCI_REGISTRY_HOSTNAME}/${OCI_REGISTRY_PROJECT_IMAGES}/${OPERATOR_NAME}:${VERSION}"
 
 helm-publish:
 	# Push to Nexus

--- a/template/Tiltfile
+++ b/template/Tiltfile
@@ -1,8 +1,8 @@
 # If tilt_options.json exists read it and load the default_registry value from it
 settings = read_json('tilt_options.json', default={})
-registry = settings.get('default_registry', 'docker.stackable.tech/sandbox')
+registry = settings.get('default_registry', 'oci.stackable.tech/sandbox')
 
-# Configure default registry either read from config file above, or with default value of "docker.stackable.tech/sandbox"
+# Configure default registry either read from config file above, or with default value of "oci.stackable.tech/sandbox"
 default_registry(registry)
 
 meta = read_json('nix/meta.json')
@@ -23,8 +23,8 @@ if os.path.exists('result'):
    k8s_yaml('result/crds.yaml')
 
 # We need to set the correct image annotation on the operator Deployment to use e.g.
-# docker.stackable.tech/sandbox/opa-operator:7y19m3d8clwxlv34v5q2x4p7v536s00g instead of
-# docker.stackable.tech/sandbox/opa-operator:0.0.0-dev (which does not exist)
+# oci.stackable.tech/sandbox/opa-operator:7y19m3d8clwxlv34v5q2x4p7v536s00g instead of
+# oci.stackable.tech/sandbox/opa-operator:0.0.0-dev (which does not exist)
 k8s_kind('Deployment', image_json_path='{.spec.template.metadata.annotations.internal\\.stackable\\.tech/image}')
 
 # Exclude stale CRDs from Helm chart, and apply the rest

--- a/template/default.nix
+++ b/template/default.nix
@@ -40,7 +40,7 @@
     };
   }
 , meta ? pkgs.lib.importJSON ./nix/meta.json
-, dockerName ? "docker.stackable.tech/sandbox/${meta.operator.name}"
+, dockerName ? "oci.stackable.tech/sandbox/${meta.operator.name}"
 , dockerTag ? null
 }:
 rec {


### PR DESCRIPTION
### Changes

- defaults (e.g. labels) are set to `oci.stackable.tech`

#### N.B. not changed (yet)

- objects are still pushed to Nexus and Harbor
  - post 25.3, pushes to Nexus will be discontinued
  - see [this](https://github.com/stackabletech/opa-operator/pull/671/commits/47ff0d19dc14623f289bf7a9e5d17ca0da9486b2) commit for necessary changes to remove Nexus actions