### PR TITLE
chore: Add rustfmt.toml with some unstable format options

### DIFF
--- a/template/.pre-commit-config.yaml.j2
+++ b/template/.pre-commit-config.yaml.j2
@@ -18,6 +18,7 @@ repos:
     rev: eeee35a89e69d5772bdee97db1a6a898467b686e # 1.0
     hooks:
       - id: fmt
+        entry: cargo +nightly fmt
         args: ["--all", "--", "--check"]
       - id: clippy
         args: ["--all-targets", "--", "-D", "warnings"]

--- a/template/.pre-commit-config.yaml.j2
+++ b/template/.pre-commit-config.yaml.j2
@@ -18,7 +18,7 @@ repos:
     rev: eeee35a89e69d5772bdee97db1a6a898467b686e # 1.0
     hooks:
       - id: fmt
-        entry: cargo +nightly fmt
+        entry: RUSTUP_TOOLCHAIN=nightly-2025-01-15 cargo fmt
         args: ["--all", "--", "--check"]
       - id: clippy
         args: ["--all-targets", "--", "-D", "warnings"]

--- a/template/.pre-commit-config.yaml.j2
+++ b/template/.pre-commit-config.yaml.j2
@@ -18,6 +18,7 @@ repos:
     rev: eeee35a89e69d5772bdee97db1a6a898467b686e # 1.0
     hooks:
       - id: fmt
+        # Pinning to a specific rustc version, so that we get consistent formatting
         entry: RUSTUP_TOOLCHAIN=nightly-2025-01-15 cargo fmt
         args: ["--all", "--", "--check"]
       - id: clippy

--- a/template/rustfmt.toml
+++ b/template/rustfmt.toml
@@ -2,3 +2,4 @@
 # It's also ok to use the stable toolchain by simple running "cargo fmt", but using the nigthly formatter is prefered.
 
 imports_granularity = "Crate"
+group_imports =  "StdExternalCrate"


### PR DESCRIPTION
Fixup of https://github.com/stackabletech/operator-templating/pull/136
Back in the day I put it in the wrong folder :man_facepalming: We already have this in secret-op for ~2 years now.

The amount of time I have seen suggestions regarding merging imports and sorting (std, external, crate), I'm very happy that we can solve all of that by automation :partying_face: 

`cargo +stable fmt` currently gives a warning, but still returns exit code 0 (so can be ignored)
Use `cargo fmt` to run the formatting.

See https://github.com/stackabletech/operator-templating/pull/136
> For what it's worth, you can run a single cargo command using the nightly toolchain by using `cargo +nightly fmt`.
>
> Rust-Analyzer should also allow you to set rustfmt-specific flags (for Emacs, put `(setq rust-rustfmt-switches '("+nightly" "--edition" "2018"))` into your `.emacs`), and I assume Rust-IntelliJ has something similar.