### PR TITLE
fix(template/helm): Add checksum/config annotation

### DIFF
--- a/template/deploy/helm/[[operator]]/templates/deployment.yaml.j2
+++ b/template/deploy/helm/[[operator]]/templates/deployment.yaml.j2
@@ -17,8 +17,8 @@ spec:
     metadata:
       annotations:
         internal.stackable.tech/image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-        {{- with .Values.podAnnotations }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:


### PR DESCRIPTION
Add the dynamic `checksum/config` annotation back in.
This is supposed to be used for rolling out the Deployment when the ConfigMap content changes.

Previously, this annotation only appeared when `.Values.podAnnotations` was set.

It was only discovered broken by adding podAnnotations and seeing that the `include` context was invalid, leading to this error:

```
Error: template: trino-operator/templates/deployment.yaml:20:28: executing "trino-operator/templates/deployment.yaml" at <include (print $.Template.BasePath "/configmap.yaml") .>: error calling include: template: trino-operator/templates/configmap.yaml:4:10: executing "trino-operator/templates/configmap.yaml" at <.Files.Glob>: nil pointer evaluating interface {}.Glob
```

Note, this was always broken since inception in #7.