### PR TITLE
fix(template/ci): Use local rustfmt hook

### DIFF
--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -5,7 +5,8 @@
 rust_version: 1.82.0
 
 # This nightly version is only used for cargo fmt invocations, because we use nightly-only
-# rustfmt config options in rustfmt.toml.
+# rustfmt config options in rustfmt.toml. The version should be kept in line with the version
+# used in the operator-rs repository.
 rust_nightly_version: nightly-2025-01-15
 
 # IMPORTANT

--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -4,6 +4,10 @@
 # docker-images/ubi8-rust-builder/Dockerfile & docker-images/ubi9-rust-builder/Dockerfile
 rust_version: 1.82.0
 
+# This nightly version is only used for cargo fmt invocations, because we use nightly-only
+# rustfmt config options in rustfmt.toml.
+rust_nightly_version: nightly-2025-01-15
+
 # IMPORTANT
 # If you change the Hadolint version here, make sure to also change the hook
 # refs in the local and templated .pre-commit-config.yaml files.

--- a/template/.github/workflows/pr_pre-commit.yaml.j2
+++ b/template/.github/workflows/pr_pre-commit.yaml.j2
@@ -6,7 +6,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_TOOLCHAIN_VERSION: "{[ rust_version }]"
+  RUST_TOOLCHAIN_VERSION: "{[ rust_nightly_version }]"
   HADOLINT_VERSION: "{[ hadolint_version }]"
   PYTHON_VERSION: "{[ python_version }]"
 

--- a/template/.pre-commit-config.yaml.j2
+++ b/template/.pre-commit-config.yaml.j2
@@ -17,10 +17,6 @@ repos:
   - repo: https://github.com/doublify/pre-commit-rust
     rev: eeee35a89e69d5772bdee97db1a6a898467b686e # 1.0
     hooks:
-      - id: fmt
-        # Pinning to a specific rustc version, so that we get consistent formatting
-        entry: RUSTUP_TOOLCHAIN=nightly-2025-01-15 cargo fmt
-        args: ["--all", "--", "--check"]
       - id: clippy
         args: ["--all-targets", "--", "-D", "warnings"]
 
@@ -77,4 +73,11 @@ repos:
         language: system
         entry: cargo test
         stages: [pre-commit, pre-merge-commit, manual]
+        pass_filenames: false
+
+      - id: cargo-rustfmt
+        name: cargo-rustfmt
+        language: system
+        entry: cargo +{[rust_nightly_version}] fmt --all -- --check
+        stages: [pre-commit]
         pass_filenames: false


### PR DESCRIPTION
This fixes the rustfmt pre-commit hook introduced in #477. Pre-commit tries to run `RUSTUP_TOOLCHAIN=nightly-2025-01-15` instead of `cargo fmt`, see [CI run](https://github.com/stackabletech/druid-operator/actions/runs/13131269765/job/36636760099#step:4:524).