### PR TITLE
chore: Pre-release updates for Stackable Release 25.3.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/pre-release.md
+++ b/.github/ISSUE_TEMPLATE/pre-release.md
@@ -46,6 +46,7 @@ Part of <https://github.com/stackabletech/issues/TRACKING_ISSUE>
 ```[tasklist]
 ### Tasks in this Repository
 - [ ] Update Rust toolchain in the `config/versions.yaml` file.
+- [ ] Update Rust toolchain in UBI8, UBI9, and stackable-base images
 - [ ] Generate downstream PRs using the ["Generate Downstream PRs"](https://github.com/stackabletech/operator-templating/actions/workflows/generate_prs.yml) action.
 - [ ] [Search for PRs](https://github.com/search?q=org%3Astackabletech%20sort%3Aupdated-desc%20is%3Apr%20is%3Aopen%20Update%20templated%20files&type=pullrequests) and add them to the task list below.
 - [ ] Merge downstream PRs, see below for more details.

--- a/.github/workflows/generate_prs.yml
+++ b/.github/workflows/generate_prs.yml
@@ -14,6 +14,8 @@ on:
         type: boolean
         default: true
 
+permissions: {}
+
 jobs:
   create-prs:
     runs-on: ubuntu-latest
@@ -101,6 +103,8 @@ jobs:
             url: stackabletech/zookeeper-operator.git
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
       - name: Install Ansible
         env:
@@ -129,9 +133,12 @@ jobs:
       # Create commit message depending on whether this is run manually or due to a scheduled run
       - name: Set commit message for manual dispatch
         if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          REASON: ${{ github.event.inputs.message }}
+          AUTHOR: ${{ github.event.sender.login }}
         run: |
-          echo "AUTHOR=${{ github.event.sender.login }}" >> "$GITHUB_ENV"
-          echo "REASON=${{ github.event.inputs.message }}" >> "$GITHUB_ENV"
+          echo "AUTHOR=$AUTHOR" >> "$GITHUB_ENV"
+          echo "REASON=$REASON" >> "$GITHUB_ENV"
       - name: Set commit message for schedule
         if: ${{ github.event_name == 'schedule' }}
         run: |

--- a/.github/workflows/generate_prs.yml
+++ b/.github/workflows/generate_prs.yml
@@ -101,7 +101,7 @@ jobs:
             url: stackabletech/zookeeper-operator.git
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # tag=v26
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
       - name: Install Ansible
         env:
           DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/pr_pre-commit.yml
+++ b/.github/workflows/pr_pre-commit.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: stackabletech/actions/run-pre-commit@e8781161bc1eb037198098334cec6061fe24b6c3 # v0.0.2
+      - uses: stackabletech/actions/run-pre-commit@2d3d7ddad981ae09901d45a0f6bf30c2658b1b78 # v0.7.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           hadolint: ${{ env.HADOLINT_VERSION }}

--- a/.github/workflows/pr_pre-commit.yml
+++ b/.github/workflows/pr_pre-commit.yml
@@ -8,12 +8,15 @@ env:
   HADOLINT_VERSION: "v2.12.0"
   PYTHON_VERSION: "3.12"
 
+permissions: {}
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          persist-credentials: false
           fetch-depth: 0
       - uses: stackabletech/actions/run-pre-commit@2d3d7ddad981ae09901d45a0f6bf30c2658b1b78 # v0.7.0
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         files: \.(yml|yaml)(\.j2)*$
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: aa975a18c9a869648007d33864034dbc7481fe5e # 0.42.0
+    rev: 586c3ea3f51230da42bab657c6a32e9e66c364f0 # 0.44.0
     hooks:
       - id: markdownlint
         types: [text]
@@ -38,7 +38,7 @@ repos:
   # If you do not, you will need to delete the cached ruff binary shown in the
   # error message
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 8983acb92ee4b01924893632cf90af926fa608f0 # 0.7.0
+    rev: 2c8dce6094fa2b4b668e74f694ca63ceffd38614 # 0.9.9
     hooks:
       # Run the linter.
       - id: ruff
@@ -46,7 +46,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/rhysd/actionlint
-    rev: 4e683ab8014a63fafa117492a0c6053758e6d593 # 1.7.3
+    rev: 03d0035246f3e81f36aed592ffb4bebf33a03106 # 1.7.7
     hooks:
       - id: actionlint
         types: [text]

--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -2,7 +2,7 @@
 # IMPORTANT
 # If you change the Rust toolchain version here, make sure to also change
 # docker-images/ubi8-rust-builder/Dockerfile & docker-images/ubi9-rust-builder/Dockerfile
-rust_version: 1.82.0
+rust_version: 1.84.1
 
 # This nightly version is only used for cargo fmt invocations, because we use nightly-only
 # rustfmt config options in rustfmt.toml. The version should be kept in line with the version

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -27,6 +27,7 @@ env:
   CARGO_INCREMENTAL: '0'
   CARGO_PROFILE_DEV_DEBUG: '0'
   RUST_TOOLCHAIN_VERSION: "{[ rust_version }]"
+  PYTHON_VERSION: "{[ python_version }]"
   RUSTFLAGS: "-D warnings"
   RUSTDOCFLAGS: "-D warnings"
   RUST_LOG: "info"
@@ -233,7 +234,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
-          python-version: '3.12'
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Install jinja2-cli
         run: pip install jinja2-cli==0.8.2
       - name: Regenerate charts

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203
+      - uses: dtolnay/rust-toolchain@c5a29ddb4d9d194e7c84ec8c3fba61b1c31fee8c
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
       - uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
-      - uses: EmbarkStudios/cargo-deny-action@8371184bd11e21dcf8ac82ebf8c9c9f74ebf7268 # v2.0.1
+      - uses: EmbarkStudios/cargo-deny-action@0484eedcba649433ebd03d9b7c9c002746bbc4b9 # v2.0.6
         with:
           command: check ${{ matrix.checks }}
 
@@ -130,7 +130,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203
+      - uses: dtolnay/rust-toolchain@c5a29ddb4d9d194e7c84ec8c3fba61b1c31fee8c
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
           components: rustfmt
@@ -148,7 +148,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203
+      - uses: dtolnay/rust-toolchain@c5a29ddb4d9d194e7c84ec8c3fba61b1c31fee8c
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
           components: clippy
@@ -183,7 +183,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203
+      - uses: dtolnay/rust-toolchain@c5a29ddb4d9d194e7c84ec8c3fba61b1c31fee8c
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
           components: rustfmt
@@ -205,7 +205,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
-      - uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203
+      - uses: dtolnay/rust-toolchain@c5a29ddb4d9d194e7c84ec8c3fba61b1c31fee8c
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
       - uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
@@ -268,7 +268,7 @@ jobs:
         with:
           version: v3.16.1
       - name: Set up cargo
-        uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203
+        uses: dtolnay/rust-toolchain@c5a29ddb4d9d194e7c84ec8c3fba61b1c31fee8c
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
       - uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
@@ -333,8 +333,8 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
-      - uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # v27
-      - uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203
+      - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+      - uses: dtolnay/rust-toolchain@c5a29ddb4d9d194e7c84ec8c3fba61b1c31fee8c
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
           components: rustfmt
@@ -371,9 +371,9 @@ jobs:
       # default value in the makefile if called from this action, but not otherwise (i.e. when called locally).
       # This is needed for the HELM_REPO variable.
       - name: Install cosign
-        uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382 # v3.6.0
+        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
       - name: Install syft
-        uses: anchore/sbom-action/download-syft@61119d458adab75f756bc0b9e4bde25725f86a7a # v0.17.2
+        uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
       - name: Build Docker image and Helm chart
         run: |
           # Installing helm and yq on ubicloud-standard-8-arm only
@@ -417,7 +417,7 @@ jobs:
       OCI_REGISTRY_SDP_CHARTS_USERNAME: "robot$sdp-charts+github-action-build"
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382 # v3.6.0
+        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -49,6 +49,7 @@ jobs:
           version: ubuntu-latest
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          persist-credentials: false
           submodules: recursive
       - uses: dtolnay/rust-toolchain@c5a29ddb4d9d194e7c84ec8c3fba61b1c31fee8c
         with:
@@ -118,6 +119,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          persist-credentials: false
           submodules: recursive
       - uses: EmbarkStudios/cargo-deny-action@0484eedcba649433ebd03d9b7c9c002746bbc4b9 # v2.0.6
         with:
@@ -129,6 +131,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          persist-credentials: false
           submodules: recursive
       - uses: dtolnay/rust-toolchain@c5a29ddb4d9d194e7c84ec8c3fba61b1c31fee8c
         with:
@@ -147,6 +150,7 @@ jobs:
           version: ubuntu-latest
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          persist-credentials: false
           submodules: recursive
       - uses: dtolnay/rust-toolchain@c5a29ddb4d9d194e7c84ec8c3fba61b1c31fee8c
         with:
@@ -204,6 +208,7 @@ jobs:
           version: ubuntu-latest
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          persist-credentials: false
           submodules: recursive
       - uses: dtolnay/rust-toolchain@c5a29ddb4d9d194e7c84ec8c3fba61b1c31fee8c
         with:
@@ -224,6 +229,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          persist-credentials: false
           submodules: recursive
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
@@ -262,6 +268,7 @@ jobs:
           version: ubuntu-latest
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          persist-credentials: false
           submodules: recursive
       - name: Set up Helm
         uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
@@ -332,6 +339,7 @@ jobs:
           version: ${{ matrix.runner }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          persist-credentials: false
           submodules: recursive
       - uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
       - uses: dtolnay/rust-toolchain@c5a29ddb4d9d194e7c84ec8c3fba61b1c31fee8c
@@ -421,6 +429,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          persist-credentials: false
           submodules: recursive
       # This step checks if the current run was triggered by a push to a pr (or a pr being created).
       # If this is the case it changes the version of this project in all Cargo.toml files to include the suffix

--- a/template/.github/workflows/general_daily_security.yml
+++ b/template/.github/workflows/general_daily_security.yml
@@ -10,11 +10,15 @@ on:
     - cron: '15 4 * * *'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: rustsec/audit-check@dd51754d4e59da7395a4cd9b593f0ff2d61a9b95 # v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/template/.github/workflows/pr_pre-commit.yaml.j2
+++ b/template/.github/workflows/pr_pre-commit.yaml.j2
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-      - uses: stackabletech/actions/run-pre-commit@5b66858af3597c4ea34f9b33664b8034a1d28427 # v0.3.0
+      - uses: stackabletech/actions/run-pre-commit@2d3d7ddad981ae09901d45a0f6bf30c2658b1b78 # v0.7.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           rust: ${{ env.RUST_TOOLCHAIN_VERSION }}

--- a/template/.github/workflows/pr_pre-commit.yaml.j2
+++ b/template/.github/workflows/pr_pre-commit.yaml.j2
@@ -21,8 +21,9 @@ jobs:
           version: ubuntu-latest
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          persist-credentials: false
           submodules: recursive
+          fetch-depth: 0
       - uses: stackabletech/actions/run-pre-commit@2d3d7ddad981ae09901d45a0f6bf30c2658b1b78 # v0.7.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}

--- a/template/.pre-commit-config.yaml.j2
+++ b/template/.pre-commit-config.yaml.j2
@@ -26,7 +26,7 @@ repos:
       - id: yamllint
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: aa975a18c9a869648007d33864034dbc7481fe5e # 0.42.0
+    rev: 586c3ea3f51230da42bab657c6a32e9e66c364f0 # 0.44.0
     hooks:
       - id: markdownlint
         types: [text]
@@ -42,7 +42,7 @@ repos:
   # If you do not, you will need to delete the cached ruff binary shown in the
   # error message
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 8983acb92ee4b01924893632cf90af926fa608f0 # 0.7.0
+    rev: 2c8dce6094fa2b4b668e74f694ca63ceffd38614 # 0.9.9
     hooks:
       # Run the linter.
       - id: ruff
@@ -50,7 +50,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/rhysd/actionlint
-    rev: 4e683ab8014a63fafa117492a0c6053758e6d593 # 1.7.3
+    rev: 03d0035246f3e81f36aed592ffb4bebf33a03106 # 1.7.7
     hooks:
       - id: actionlint
 

--- a/template/.pre-commit-config.yaml.j2
+++ b/template/.pre-commit-config.yaml.j2
@@ -14,12 +14,6 @@ repos:
         args: ["--allow-missing-credentials"]
       - id: detect-private-key
 
-  - repo: https://github.com/doublify/pre-commit-rust
-    rev: eeee35a89e69d5772bdee97db1a6a898467b686e # 1.0
-    hooks:
-      - id: clippy
-        args: ["--all-targets", "--", "-D", "warnings"]
-
   - repo: https://github.com/adrienverge/yamllint
     rev: 81e9f98ffd059efe8aa9c1b1a42e5cce61b640c6 # 1.35.1
     hooks:
@@ -74,6 +68,7 @@ repos:
         entry: cargo test
         stages: [pre-commit, pre-merge-commit, manual]
         pass_filenames: false
+        files: \.rs$|Cargo\.(toml|lock)
 
       - id: cargo-rustfmt
         name: cargo-rustfmt
@@ -81,3 +76,12 @@ repos:
         entry: cargo +{[rust_nightly_version}] fmt --all -- --check
         stages: [pre-commit]
         pass_filenames: false
+        files: \.rs$
+
+      - id: cargo-clippy
+        name: cargo-clippy
+        language: system
+        entry: cargo clippy --all-targets -- -D warnings
+        stages: [pre-commit]
+        pass_filenames: false
+        files: \.rs$


### PR DESCRIPTION
Part of <https://github.com/stackabletech/operator-templating/issues/484>

- Bumps local and templated workflow actions
- Hardens local and templated workflows
- Bumps local and templated pre-commit hooks
- Bumps the Rust toolchain to 1.84.1