### PR TITLE
template(ci): Bump cargo-deny-action to 2.0.7

### DIFF
--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -122,7 +122,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - uses: EmbarkStudios/cargo-deny-action@0484eedcba649433ebd03d9b7c9c002746bbc4b9 # v2.0.6
+      - uses: EmbarkStudios/cargo-deny-action@8d73959fce1cdc8989f23fdf03bec6ae6a6576ef # v2.0.7
         with:
           command: check ${{ matrix.checks }}
 


### PR DESCRIPTION
Part of <https://github.com/stackabletech/operator-templating/issues/484>

A new version of the cargo-deny-action was released because of the rustup 1.28 change of behaviour, see https://github.com/EmbarkStudios/cargo-deny-action/pull/92.

This change is already rolled out using the PRs from the previous rollout of #485.