### PR TITLE
Add functionality to allow configuring the loglevel the operator is deployed with in the Helm chart

### DIFF
--- a/template/Tiltfile
+++ b/template/Tiltfile
@@ -1,6 +1,7 @@
 # If tilt_options.json exists read it and load the default_registry value from it
 settings = read_json('tilt_options.json', default={})
 registry = settings.get('default_registry', 'oci.stackable.tech/sandbox')
+loglevel = settings.get('loglevel', '')
 
 # Configure default registry either read from config file above, or with default value of "oci.stackable.tech/sandbox"
 default_registry(registry)
@@ -35,6 +36,7 @@ helm_crds, helm_non_crds = filter_yaml(
       namespace="stackable-operators",
       set=[
          'image.repository=' + registry + '/' + operator_name,
+         'logLevel=' + loglevel
       ],
    ),
    api_version = "^apiextensions\\.k8s\\.io/.*$",

--- a/template/deploy/helm/[[operator]]/templates/deployment.yaml.j2
+++ b/template/deploy/helm/[[operator]]/templates/deployment.yaml.j2
@@ -52,6 +52,10 @@ spec:
             - name: KUBERNETES_CLUSTER_DOMAIN
               value: {{ .Values.kubernetesClusterDomain | quote }}
             {{- end }}
+            {{- if .Values.logLevel }}
+            - name: {[ operator.product_string | upper }]_OPERATOR_LOG
+              value: {{ .Values.logLevel | quote }}
+            {{- end }}
 {[% if operator.product_string in ['kafka'] %}]
             - name: KAFKA_BROKER_CLUSTERROLE
               value: {{ include "operator.fullname" . }}-kafka-broker-clusterrole


### PR DESCRIPTION
This introduces a variable called 'logLevel' which, when set to an empty string is not propagated to the deployment by the Helm chart at all, so that the default value for the loglevel in the operator code remains effective.

When set to a non-empty string the value is propagated as environment variable <PRODUCTNAME>_OPERATOR_LOG into the pod template of the operator deployment.

Additionally this adds code to the Tiltfile that allows configuring this via a local override, in a similar fashion to what we already allow for the default registry.

Users can create a file called `tilt_options.json` and in there define a loglevel as follows: 
```json
{
  "loglevel": "DEBUG"
}
```

When this file is present the value from here will be read and passed to the Helm chart by Tilt. If this file is not present, an empty string is passed through, triggering the behavior described above where the default loglevel defined in the operator code remains effective.

This PR doesn't introduce a default for the 'logLevel' variable in the Helm charts, as the `values.yaml` files are not managed by templating. However adding a default for that variable should be an optional step, that we can do later at our convenience, or totally omit, since an unset value will just fall through to the default loglevel from code again.