### PR TITLE
fix(template): Use nightly toolchain for cargo udeps

### DIFF
--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -55,7 +55,7 @@ jobs:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@c5a29ddb4d9d194e7c84ec8c3fba61b1c31fee8c
         with:
-          toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN_VERSION }}
       - uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
         with:
           key: udeps


### PR DESCRIPTION
> [!CAUTION]
> Do not merge. It hasn't seemed to fix the problem in CI (though it does work locally).

`cargo udeps` was failing on the `1.85.0` toolchain, but it seems to work on nightly.
