### PR TITLE
chore(template): Template Rust edition in rustfmt config

### DIFF
--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -9,6 +9,10 @@ rust_version: 1.85.0
 # used in the operator-rs repository.
 rust_nightly_version: nightly-2025-01-15
 
+# This edition is mostly used for rustfmt commands and the rustfmt config file. The edition should
+# be kept in line with the edition in the operator-rs repository.
+rust_edition: 2024
+
 # IMPORTANT
 # If you change the Hadolint version here, make sure to also change the hook
 # refs in the local and templated .pre-commit-config.yaml files.

--- a/template/.vscode/settings.json.j2
+++ b/template/.vscode/settings.json.j2
@@ -2,6 +2,8 @@
     "rust-analyzer.rustfmt.overrideCommand": [
         "rustfmt",
         "+{[rust_nightly_version}]",
+        "--edition",
+        "{[rust_edition}]",
         "--"
     ],
 }

--- a/template/rustfmt.toml.j2
+++ b/template/rustfmt.toml.j2
@@ -2,7 +2,7 @@
 # It's also ok to use the stable toolchain by simple running "cargo fmt", but using the nigthly formatter is prefered.
 
 # https://doc.rust-lang.org/nightly/edition-guide/rust-2024/rustfmt-style-edition.html
-style_edition = "2024"
+style_edition = "{[rust_edition}]"
 imports_granularity = "Crate"
 group_imports = "StdExternalCrate"
 reorder_impl_items = true


### PR DESCRIPTION
If the `rustfmt` command in `.vscode/settings.json` is overwritten, the edition needs to be provided explicitly as otherwise the command will fail and no formatting on save is performed.