### PR TITLE
chore(template): Add Helm helper for telemetry env vars

### DIFF
--- a/template/deploy/helm/[[operator]]/templates/_telemetry.tpl
+++ b/template/deploy/helm/[[operator]]/templates/_telemetry.tpl
@@ -1,0 +1,51 @@
+{{/*
+Create a list of telemetry related env vars.
+*/}}
+{{- define "telemetry.envVars" -}}
+{{- with .Values.telemetry }}
+{{- if not .consoleLogs.enabled }}
+- name: NO_CONSOLE_OUTPUT
+  value: "true"
+{{- end }}
+{{- if .consoleLogs.level }}
+- name: CONSOLE_LOG
+  value: {{ .consoleLogs.level }}
+{{ end }}
+{{- if .rollingFileLogs.enabled }}
+- name: ROLLING_LOGS_DIR
+  value: /stackable/logs/{{ include "operator.appname" $ }}
+{{- end }}
+{{- if .rollingFileLogs.level }}
+- name: FILE_LOG
+  value: info
+{{- end }}
+{{- if .rollingFileLogs.period }}
+- name: ROLLING_LOGS_PERIOD
+  value: {{ .rollingFileLogs.period }}
+{{- end }}
+{{- if .otlpLogs.enabled }}
+- name: OTLP_LOGS
+  value: "true"
+{{- end }}
+{{- if .otlpLogs.level }}
+- name: OTLP_LOG
+  value: {{ .otlpLogs.level }}
+{{- end }}
+{{- if .otlpLogs.endpoint }}
+- name: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
+  value: {{ .otlpLogs.endpoint }}
+{{- end }}
+{{- if .otlpTraces.enabled }}
+- name: OTLP_TRACES
+  value: "true"
+{{- end }}
+{{- if .otlpTraces.level }}
+- name: OTLP_TRACE
+  value: {{ .otlpTraces.level }}
+{{- end }}
+{{- if .otlpTraces.endpoint }}
+- name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+  value: {{ .otlpTraces.endpoint }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/template/deploy/helm/[[operator]]/templates/_telemetry.tpl
+++ b/template/deploy/helm/[[operator]]/templates/_telemetry.tpl
@@ -27,6 +27,10 @@ Create a list of telemetry related env vars.
 - name: FILE_LOG_ROTATION_PERIOD
   value: {{ .fileLog.rotationPeriod }}
 {{- end }}
+{{- if .fileLog.maxFiles }}
+- name: FILE_LOG_MAX_FILES
+  value: {{ .fileLog.maxFiles }}
+{{- end }}
 {{- if .otelLogExporter.enabled }}
 - name: OTEL_LOG_EXPORTER_ENABLED
   value: "true"

--- a/template/deploy/helm/[[operator]]/templates/_telemetry.tpl
+++ b/template/deploy/helm/[[operator]]/templates/_telemetry.tpl
@@ -3,49 +3,49 @@ Create a list of telemetry related env vars.
 */}}
 {{- define "telemetry.envVars" -}}
 {{- with .Values.telemetry }}
-{{- if not .consoleLogs.enabled }}
-- name: NO_CONSOLE_OUTPUT
+{{- if not .consoleLog.enabled }}
+- name: CONSOLE_LOG_DISABLED
   value: "true"
 {{- end }}
-{{- if .consoleLogs.level }}
-- name: CONSOLE_LOG
-  value: {{ .consoleLogs.level }}
+{{- if .consoleLog.level }}
+- name: CONSOLE_LOG_LEVEL
+  value: {{ .consoleLog.level }}
 {{ end }}
-{{- if .rollingFileLogs.enabled }}
-- name: ROLLING_LOGS_DIR
+{{- if .fileLog.enabled }}
+- name: FILE_LOG_DIRECTORY
   value: /stackable/logs/{{ include "operator.appname" $ }}
 {{- end }}
-{{- if .rollingFileLogs.level }}
-- name: FILE_LOG
+{{- if .fileLog.level }}
+- name: FILE_LOG_LEVEL
   value: info
 {{- end }}
-{{- if .rollingFileLogs.period }}
-- name: ROLLING_LOGS_PERIOD
-  value: {{ .rollingFileLogs.period }}
+{{- if .fileLog.rotationPeriod }}
+- name: FILE_LOG_ROTATION_PERIOD
+  value: {{ .fileLog.rotationPeriod }}
 {{- end }}
-{{- if .otlpLogs.enabled }}
-- name: OTLP_LOGS
+{{- if .otelLogExporter.enabled }}
+- name: OTEL_LOG_EXPORTER_ENABLED
   value: "true"
 {{- end }}
-{{- if .otlpLogs.level }}
-- name: OTLP_LOG
-  value: {{ .otlpLogs.level }}
+{{- if .otelLogExporter.level }}
+- name: OTEL_LOG_EXPORTER_LEVEL
+  value: {{ .otelLogExporter.level }}
 {{- end }}
-{{- if .otlpLogs.endpoint }}
+{{- if .otelLogExporter.endpoint }}
 - name: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
-  value: {{ .otlpLogs.endpoint }}
+  value: {{ .otelLogExporter.endpoint }}
 {{- end }}
-{{- if .otlpTraces.enabled }}
-- name: OTLP_TRACES
+{{- if .otelTraceExporter.enabled }}
+- name: OTEL_TRACE_EXPORTER_ENABLED
   value: "true"
 {{- end }}
-{{- if .otlpTraces.level }}
-- name: OTLP_TRACE
-  value: {{ .otlpTraces.level }}
+{{- if .otelTraceExporter.level }}
+- name: OTEL_TRACE_EXPORTER_LEVEL
+  value: {{ .otelTraceExporter.level }}
 {{- end }}
-{{- if .otlpTraces.endpoint }}
+{{- if .otelTraceExporter.endpoint }}
 - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-  value: {{ .otlpTraces.endpoint }}
+  value: {{ .otelTraceExporter.endpoint }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/template/deploy/helm/[[operator]]/templates/_telemetry.tpl
+++ b/template/deploy/helm/[[operator]]/templates/_telemetry.tpl
@@ -11,6 +11,10 @@ Create a list of telemetry related env vars.
 - name: CONSOLE_LOG_LEVEL
   value: {{ .consoleLog.level }}
 {{ end }}
+{{- if .consoleLog.format }}
+- name: CONSOLE_LOG_FORMAT
+  value: {{ .consoleLog.format }}
+{{ end }}
 {{- if .fileLog.enabled }}
 - name: FILE_LOG_DIRECTORY
   value: /stackable/logs/{{ include "operator.appname" $ }}

--- a/template/deploy/helm/[[operator]]/templates/_telemetry.tpl
+++ b/template/deploy/helm/[[operator]]/templates/_telemetry.tpl
@@ -17,7 +17,7 @@ Create a list of telemetry related env vars.
 {{- end }}
 {{- if .fileLog.level }}
 - name: FILE_LOG_LEVEL
-  value: info
+  value: {{ .fileLog.level }}
 {{- end }}
 {{- if .fileLog.rotationPeriod }}
 - name: FILE_LOG_ROTATION_PERIOD

--- a/template/deploy/helm/[[operator]]/templates/deployment.yaml.j2
+++ b/template/deploy/helm/[[operator]]/templates/deployment.yaml.j2
@@ -52,6 +52,7 @@ spec:
             - name: KUBERNETES_CLUSTER_DOMAIN
               value: {{ .Values.kubernetesClusterDomain | quote }}
             {{- end }}
+            {{- include "telemetry.envVars" . | nindent 12 }}
 {[% if operator.product_string in ['kafka'] %}]
             - name: KAFKA_BROKER_CLUSTERROLE
               value: {{ include "operator.fullname" . }}-kafka-broker-clusterrole


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/639

Depends on
- https://github.com/stackabletech/operator-rs/pull/1009
- https://github.com/stackabletech/operator-rs/pull/1010
- https://github.com/stackabletech/operator-rs/pull/1012

This adds the `telemetry.envVars` Helm helper to create a list of environment variables passed on the `.telemetry` values.

**Example**

Given these values form the Helm `values.yaml` file

```yaml
telemetry:
  consoleLog:
    enabled: false
    level: warn
    format: json
  fileLog:
    enabled: true
    level: debug
    rotationPeriod: hourly
    maxFiles: 6
  otelLogExporter:
    enabled: true
    level: trace
    endpoint: my-collector:4317
  otelTraceExporter:
    enabled: true
    level: error
    endpoint: my-collector:4317
```

the rendered env block in the Deployment looks like

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: foo-operator-airflow-operator-deployment
spec:
  template:
    spec:
      containers:
        - name: airflow-operator
          env:
            - name: CONSOLE_LOG_DISABLED
              value: "true"
            - name: CONSOLE_LOG_LEVEL
              value: warn
            - name: CONSOLE_LOG_FORMAT
              value: json
            - name: FILE_LOG_DIRECTORY
              value: /stackable/logs/airflow-operator
            - name: FILE_LOG_LEVEL
              value: debug
            - name: FILE_LOG_ROTATION_PERIOD
              value: hourly
            - name: FILE_LOG_MAX_FILES
              value: 6
            - name: OTEL_LOG_EXPORTER_ENABLED
              value: "true"
            - name: OTEL_LOG_EXPORTER_LEVEL
              value: trace
            - name: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
              value: my-collector:4317
            - name: OTEL_TRACE_EXPORTER_ENABLED
              value: "true"
            - name: OTEL_TRACE_EXPORTER_LEVEL
              value: error
            - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
              value: my-collector:4317
```

Default values will be set according to the design laid out in the [tracking issue](https://github.com/stackabletech/issues/issues/639).