### PR TITLE
chore(template): Only emit env vars if telemetry signals are enabled

### DIFF
--- a/template/deploy/helm/[[operator]]/templates/_telemetry.tpl
+++ b/template/deploy/helm/[[operator]]/templates/_telemetry.tpl
@@ -7,11 +7,11 @@ Create a list of telemetry related env vars.
 - name: CONSOLE_LOG_DISABLED
   value: "true"
 {{- end }}
-{{- if .consoleLog.level }}
+{{- if and .consoleLog.enabled .consoleLog.level }}
 - name: CONSOLE_LOG_LEVEL
   value: {{ .consoleLog.level }}
 {{ end }}
-{{- if .consoleLog.format }}
+{{- if and .consoleLog.enabled .consoleLog.format }}
 - name: CONSOLE_LOG_FORMAT
   value: {{ .consoleLog.format }}
 {{ end }}
@@ -19,15 +19,15 @@ Create a list of telemetry related env vars.
 - name: FILE_LOG_DIRECTORY
   value: /stackable/logs/{{ include "operator.appname" $ }}
 {{- end }}
-{{- if .fileLog.level }}
+{{- if and .fileLog.enabled .fileLog.level }}
 - name: FILE_LOG_LEVEL
   value: {{ .fileLog.level }}
 {{- end }}
-{{- if .fileLog.rotationPeriod }}
+{{- if and .fileLog.enabled .fileLog.rotationPeriod }}
 - name: FILE_LOG_ROTATION_PERIOD
   value: {{ .fileLog.rotationPeriod }}
 {{- end }}
-{{- if .fileLog.maxFiles }}
+{{- if and .fileLog.enabled .fileLog.maxFiles }}
 - name: FILE_LOG_MAX_FILES
   value: {{ .fileLog.maxFiles }}
 {{- end }}
@@ -35,11 +35,11 @@ Create a list of telemetry related env vars.
 - name: OTEL_LOG_EXPORTER_ENABLED
   value: "true"
 {{- end }}
-{{- if .otelLogExporter.level }}
+{{- if and .otelLogExporter.enabled .otelLogExporter.level }}
 - name: OTEL_LOG_EXPORTER_LEVEL
   value: {{ .otelLogExporter.level }}
 {{- end }}
-{{- if .otelLogExporter.endpoint }}
+{{- if and .otelLogExporter.enabled .otelLogExporter.endpoint }}
 - name: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
   value: {{ .otelLogExporter.endpoint }}
 {{- end }}
@@ -47,11 +47,11 @@ Create a list of telemetry related env vars.
 - name: OTEL_TRACE_EXPORTER_ENABLED
   value: "true"
 {{- end }}
-{{- if .otelTraceExporter.level }}
+{{- if and .otelTraceExporter.enabled .otelTraceExporter.level }}
 - name: OTEL_TRACE_EXPORTER_LEVEL
   value: {{ .otelTraceExporter.level }}
 {{- end }}
-{{- if .otelTraceExporter.endpoint }}
+{{- if and .otelTraceExporter.enabled .otelTraceExporter.endpoint }}
 - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
   value: {{ .otelTraceExporter.endpoint }}
 {{- end }}


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/639, follow-up of #501 

This improves the telemetry Helm helper to only emit env vars (e.g. for level) when the appropriate signal is enabled. This will no longer emit env vars even though the signal it self is disabled.