### PR TITLE
fix(template): Quote fileLog.maxFiles env var in Helm helper

### DIFF
--- a/template/deploy/helm/[[operator]]/templates/_telemetry.tpl
+++ b/template/deploy/helm/[[operator]]/templates/_telemetry.tpl
@@ -29,7 +29,7 @@ Create a list of telemetry related env vars.
 {{- end }}
 {{- if and .fileLog.enabled .fileLog.maxFiles }}
 - name: FILE_LOG_MAX_FILES
-  value: {{ .fileLog.maxFiles }}
+  value: {{ quote .fileLog.maxFiles }}
 {{- end }}
 {{- if .otelLogExporter.enabled }}
 - name: OTEL_LOG_EXPORTER_ENABLED


### PR DESCRIPTION
This fixes the currently broken Helm files. Values of env vars need to be strings. The Helm deployment will otherwise fail with the following error:

```
Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal number
into Go struct field EnvVar.spec.template.spec.containers.env.value of type string
```