### PR TITLE
ci(generate_prs): Add option to disable strategy.fail-fast

### DIFF
--- a/.github/workflows/generate_prs.yml
+++ b/.github/workflows/generate_prs.yml
@@ -15,6 +15,10 @@ on:
         description: "Dry Run (PRs are not generated)"
         type: boolean
         default: true
+      fail-fast:
+        description: "Fail fast (if one job fails, all other are cancelled)"
+        type: boolean
+        default: true
 
 permissions: {}
 
@@ -22,6 +26,7 @@ jobs:
   create-prs:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: ${{ inputs.fail-fast }}
       # If you add a new repository here, also add it to config/repositories.yaml
       matrix:
         repository:


### PR DESCRIPTION
This adds the option to disable `strategy.fail-fast` if desired. This can help in situations where single jobs fail (e.g. due to upstream server errors), but other jobs get passed that error.

It is then possible to only re-run the failed jobs afterwards, instead of trying to run all of them together and having them succeed in one go.