### PR TITLE
ci(generate_prs): Set fail-fast input default value to false

### DIFF
--- a/.github/workflows/generate_prs.yml
+++ b/.github/workflows/generate_prs.yml
@@ -18,7 +18,7 @@ on:
       fail-fast:
         description: "Fail fast (if one job fails, all other are cancelled)"
         type: boolean
-        default: true
+        default: false
 
 permissions: {}
 


### PR DESCRIPTION
This is what we want in most situations, so set the default accordingly.