### PR TITLE
chore(template): Add regenerate-nix to pre-commit config

### DIFF
--- a/template/.pre-commit-config.yaml.j2
+++ b/template/.pre-commit-config.yaml.j2
@@ -61,6 +61,7 @@ repos:
         entry: make regenerate-charts
         stages: [pre-commit, pre-merge-commit, manual]
         pass_filenames: false
+        files: \.rs$|Cargo\.(toml|lock)
 
       - id: regenerate-nix
         name: regenerate-nix

--- a/template/.pre-commit-config.yaml.j2
+++ b/template/.pre-commit-config.yaml.j2
@@ -59,7 +59,7 @@ repos:
         name: regenerate-charts
         language: system
         entry: make regenerate-charts
-        stages: [pre-commit, pre-merge-commit, manual]
+        stages: [pre-commit, pre-merge-commit]
         pass_filenames: false
         files: \.rs$|Cargo\.(toml|lock)
 
@@ -75,7 +75,7 @@ repos:
         name: cargo-test
         language: system
         entry: cargo test
-        stages: [pre-commit, pre-merge-commit, manual]
+        stages: [pre-commit, pre-merge-commit]
         pass_filenames: false
         files: \.rs$|Cargo\.(toml|lock)
 
@@ -83,7 +83,7 @@ repos:
         name: cargo-rustfmt
         language: system
         entry: cargo +{[rust_nightly_version}] fmt --all -- --check
-        stages: [pre-commit]
+        stages: [pre-commit, pre-merge-commit]
         pass_filenames: false
         files: \.rs$
 
@@ -91,6 +91,6 @@ repos:
         name: cargo-clippy
         language: system
         entry: cargo clippy --all-targets -- -D warnings
-        stages: [pre-commit]
+        stages: [pre-commit, pre-merge-commit]
         pass_filenames: false
         files: \.rs$

--- a/template/.pre-commit-config.yaml.j2
+++ b/template/.pre-commit-config.yaml.j2
@@ -62,6 +62,14 @@ repos:
         stages: [pre-commit, pre-merge-commit, manual]
         pass_filenames: false
 
+      - id: regenerate-nix
+        name: regenerate-nix
+        language: system
+        entry: make regenerate-nix
+        stages: [pre-commit, pre-merge-commit]
+        pass_filename: false
+        files: Cargo\.lock
+
       - id: cargo-test
         name: cargo-test
         language: system


### PR DESCRIPTION
This PR:

- adds the `make regenerate-nix` command as a pre-commit hook to keep Nix files up to date.
- improves on which file changes the `regenerate-charts` hook runs.
- improves in which stages the local pre-commit hooks run.