### PR TITLE
ci(template): Install Nix in pre-commit workflow

### DIFF
--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -23,3 +23,7 @@ hadolint_version: v2.12.0
 # If you change the Python version here, make sure to also change it in
 # .github/workflows/pr_pre-commit.yml
 python_version: 3.12
+
+# This Nix version is used in the operators pre-commit workflow as they require
+# Nix to ron some checks.
+nix_pkg_manager_version: 2.28.3

--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -25,5 +25,5 @@ hadolint_version: v2.12.0
 python_version: 3.12
 
 # This Nix version is used in the operators pre-commit workflow as they require
-# Nix to ron some checks.
+# Nix to run some checks.
 nix_pkg_manager_version: 2.28.3

--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -25,9 +25,8 @@ hadolint_version: v2.12.0
 python_version: 3.12
 
 # This Nix version is used in the operators pre-commit workflow as they require
-# Nix to run some checks. Places to check for versions:
-# - https://github.com/NixOS/nix/tags
-# - https://nixos.org/download/#
+# Nix to run some checks. Check for new versions here:
+# https://github.com/NixOS/nix/tags
 # Usually the latest version should just work and as such the version here can
 # be bumped without any constraints.
 nix_pkg_manager_version: 2.28.3

--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -25,5 +25,9 @@ hadolint_version: v2.12.0
 python_version: 3.12
 
 # This Nix version is used in the operators pre-commit workflow as they require
-# Nix to run some checks.
+# Nix to run some checks. Places to check for versions:
+# - https://github.com/NixOS/nix/tags
+# - https://nixos.org/download/#
+# Usually the latest version should just work and as such the version here can
+# be bumped without any constraints.
 nix_pkg_manager_version: 2.28.3

--- a/template/.github/workflows/pr_pre-commit.yaml.j2
+++ b/template/.github/workflows/pr_pre-commit.yaml.j2
@@ -6,6 +6,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  NIX_PKG_MANAGER_VERSION: "{[ nix_pkg_manager_version }]"
   RUST_TOOLCHAIN_VERSION: "{[ rust_nightly_version }]"
   HADOLINT_VERSION: "{[ hadolint_version }]"
   PYTHON_VERSION: "{[ python_version }]"
@@ -29,3 +30,5 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           rust: ${{ env.RUST_TOOLCHAIN_VERSION }}
           hadolint: ${{ env.HADOLINT_VERSION }}
+          nix: ${{ env.NIX_PKG_MANAGER_VERSION }}
+          nix-github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Came up in https://github.com/stackabletech/secret-operator/actions/runs/14877437184/job/41777443726.

Currently, the pre-commit workflow will fail, because Nix (the package manager) is not installed. This PR installs it in the latest version (2.28.3).