### PR TITLE
ci(template): Use pinned rustup version

### DIFF
--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -13,6 +13,13 @@ rust_nightly_version: nightly-2025-01-15
 # be kept in line with the edition in the operator-rs repository.
 rust_edition: 2024
 
+# This value is used to pin (possible since https://github.com/rust-lang/rustup/pull/4259) the
+# rustup version used in CI because rustup introduced multiple breaking changes in the past, see:
+# - https://github.com/rust-lang/rustup/issues/4211
+# - https://github.com/rust-lang/rustup/issues/4337
+# Check for new versions here: https://github.com/rust-lang/rustup/tags
+rustup_version: 1.28.1
+
 # IMPORTANT
 # If you change the Hadolint version here, make sure to also change the hook
 # refs in the local and templated .pre-commit-config.yaml files.

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -28,6 +28,7 @@ env:
   CARGO_PROFILE_DEV_DEBUG: '0'
   RUST_TOOLCHAIN_VERSION: "{[ rust_version }]"
   RUST_NIGHTLY_TOOLCHAIN_VERSION: "{[ rust_nightly_version }]"
+  RUSTUP_VERSION: "{[ rustup_version }]"
   PYTHON_VERSION: "{[ python_version }]"
   RUSTFLAGS: "-D warnings"
   RUSTDOCFLAGS: "-D warnings"
@@ -53,6 +54,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          rustup-version: ${{ env.RUSTUP_VERSION }}
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
         with:
           key: udeps
@@ -129,6 +131,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0
         with:
           toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN_VERSION }}
+          rustup-version: ${{ env.RUSTUP_VERSION }}
           components: rustfmt
       - env:
           RUST_TOOLCHAIN_VERSION: ${{ env.RUST_NIGHTLY_TOOLCHAIN_VERSION }}
@@ -150,6 +153,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          rustup-version: ${{ env.RUSTUP_VERSION }}
           components: clippy
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
         with:
@@ -188,6 +192,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          rustup-version: ${{ env.RUSTUP_VERSION }}
           components: rustfmt
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
         with:
@@ -212,6 +217,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          rustup-version: ${{ env.RUSTUP_VERSION }}
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
         with:
           key: test
@@ -277,6 +283,7 @@ jobs:
         uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          rustup-version: ${{ env.RUSTUP_VERSION }}
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
         with:
           key: charts
@@ -344,6 +351,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          rustup-version: ${{ env.RUSTUP_VERSION }}
           components: rustfmt
         # This step checks if the current run was triggered by a push to a pr (or a pr being created).
         # If this is the case it changes the version of this project in all Cargo.toml files to include the suffix

--- a/template/.github/workflows/pr_pre-commit.yaml.j2
+++ b/template/.github/workflows/pr_pre-commit.yaml.j2
@@ -10,6 +10,7 @@ env:
   NIX_PKG_MANAGER_VERSION: "{[ nix_pkg_manager_version }]"
   RUST_TOOLCHAIN_VERSION: "{[ rust_nightly_version }]"
   HADOLINT_VERSION: "{[ hadolint_version }]"
+  RUSTUP_VERSION: "{[ rustup_version }]"
   PYTHON_VERSION: "{[ python_version }]"
 
 jobs:
@@ -30,6 +31,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           rust: ${{ env.RUST_TOOLCHAIN_VERSION }}
+          rustup-version: ${{ env.RUSTUP_VERSION }}
           hadolint: ${{ env.HADOLINT_VERSION }}
           nix: ${{ env.NIX_PKG_MANAGER_VERSION }}
           nix-github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR depends on https://github.com/stackabletech/actions/pull/44 and https://github.com/dtolnay/rust-toolchain/pull/154.