### PR TITLE
update dependencies & add hadolint config & fix markdownlint

### DIFF
--- a/.github/workflows/pr_pre-commit.yml
+++ b/.github/workflows/pr_pre-commit.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-      - uses: stackabletech/actions/run-pre-commit@4bfd3b65f22af597fe784599c077dc34bf5894a7 # v0.8.0
+      - uses: stackabletech/actions/run-pre-commit@9aae2d1c14239021bfa33c041010f6fb7adec815 # v0.8.2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           hadolint: ${{ env.HADOLINT_VERSION }}

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -340,7 +340,7 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - uses: cachix/install-nix-action@754537aaedb35f72ab11a60cc162c49ef3016495 # v31.2.0
+      - uses: cachix/install-nix-action@17fe5fb4a23ad6cbbe47d6b3f359611ad276644c # v31.4.0
       - uses: dtolnay/rust-toolchain@56f84321dbccf38fb67ce29ab63e4754056677e0
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
@@ -378,7 +378,7 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3.8.2
       - name: Install syft
-        uses: anchore/sbom-action/download-syft@f325610c9f50a54015d37c8d16cb3b0e2c8f4de0 # v0.18.0
+        uses: anchore/sbom-action/download-syft@e11c554f704a0b820cbf8c51673f6945e0731532 # v0.20.0
       - name: Build Docker image and Helm chart
         run: |
           # Installing helm and yq on ubicloud-standard-8-arm only

--- a/template/.github/workflows/integration-test.yml
+++ b/template/.github/workflows/integration-test.yml
@@ -97,7 +97,7 @@ jobs:
         if: ${{ failure() }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_INTEGRATION_TEST_TOKEN }}
-        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1
         with:
           channel-id: "C07UYJYSMSN" # notifications-integration-tests
           payload: |

--- a/template/.github/workflows/pr_pre-commit.yaml.j2
+++ b/template/.github/workflows/pr_pre-commit.yaml.j2
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
           submodules: recursive
           fetch-depth: 0
-      - uses: stackabletech/actions/run-pre-commit@4bfd3b65f22af597fe784599c077dc34bf5894a7 # v0.8.0
+      - uses: stackabletech/actions/run-pre-commit@9aae2d1c14239021bfa33c041010f6fb7adec815 # v0.8.2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           rust: ${{ env.RUST_TOOLCHAIN_VERSION }}

--- a/template/.hadolint.yaml
+++ b/template/.hadolint.yaml
@@ -1,0 +1,11 @@
+---
+ignored:
+  # Warning: Use the -y switch to avoid manual input dnf install -y <package>
+  # https://github.com/hadolint/hadolint/wiki/DL3038
+  # Reason: We set `assumeyes=True` in dnf.conf in our base image
+  - DL3038
+
+  # Warning: Specify version with dnf install -y <package>-<version>
+  # https://github.com/hadolint/hadolint/wiki/DL3041
+  # Reason: It's good advice, but we're not set up to pin versions just yet
+  - DL3041

--- a/template/.markdownlint.yaml
+++ b/template/.markdownlint.yaml
@@ -22,3 +22,6 @@ MD033:
 MD024:
   # Only check sibling headings
   siblings_only: true
+
+# MD041/first-line-heading/first-line-h1 First line in a file should be a top-level heading
+MD041: false # Github issues and PRs already have titles, and H1 is enormous in the description box.

--- a/template/.pre-commit-config.yaml.j2
+++ b/template/.pre-commit-config.yaml.j2
@@ -15,12 +15,12 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: 81e9f98ffd059efe8aa9c1b1a42e5cce61b640c6 # 1.35.1
+    rev: 79a6b2b1392eaf49cdd32ac4f14be1a809bbd8f7 # 1.37.0
     hooks:
       - id: yamllint
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: 586c3ea3f51230da42bab657c6a32e9e66c364f0 # 0.44.0
+    rev: 192ad822316c3a22fb3d3cc8aa6eafa0b8488360 # 0.45.0
     hooks:
       - id: markdownlint
         types: [text]
@@ -36,7 +36,7 @@ repos:
   # If you do not, you will need to delete the cached ruff binary shown in the
   # error message
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 2c8dce6094fa2b4b668e74f694ca63ceffd38614 # 0.9.9
+    rev: d19233b89771be2d89273f163f5edc5a39bbc34a # 0.11.12
     hooks:
       # Run the linter.
       - id: ruff

--- a/template/docker/Dockerfile.j2
+++ b/template/docker/Dockerfile.j2
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.15.1@sha256:9857836c9ee4268391bb5b09f9f157f3c91bb15821bb77969642813b0d00518d
+# syntax=docker/dockerfile:1.16.0@sha256:e2dd261f92e4b763d789984f6eab84be66ab4f5f08052316d8eb8f173593acf7
 # NOTE: The syntax directive needs to be the first line in a Dockerfile
 # Find the latest versions here: https://hub.docker.com/r/docker/dockerfile/tags
 # And the changelogs: https://docs.docker.com/build/buildkit/dockerfile-release-notes/ or https://github.com/moby/buildkit/releases
@@ -26,6 +26,13 @@ ARG RELEASE="1"
 # These are chosen at random and are this high on purpose to have very little chance to clash with an existing user or group on the host system
 ARG STACKABLE_USER_GID="574654813"
 ARG STACKABLE_USER_UID="782252253"
+
+# Sets the default shell to Bash with strict error handling and robust pipeline processing.
+# "-e": Exits immediately if a command exits with a non-zero status
+# "-u": Treats unset variables as an error, preventing unexpected behavior from undefined variables.
+# "-o pipefail": Causes a pipeline to return the exit status of the last command in the pipe that failed, ensuring errors in any part of a pipeline are not ignored.
+# "-c": Allows the execution of commands passed as a string
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 # These labels have mostly been superceded by the OpenContainer spec annotations below but it doesn't hurt to include them
 # http://label-schema.org/rc1/
@@ -75,6 +82,8 @@ assumeyes=True
 tsflags=nodocs
 EOF
 
+# It complains about echo flags not being available in POSIX sh but we set the shell to bash
+# hadolint ignore=SC3037
 RUN <<EOF
 # Update image and install kerberos client libraries as well as some other utilities
 microdnf update


### PR DESCRIPTION
The latest templating run caused pre-commit failures:

- hadolint complained about the Dockerfile which is why I added a SHELL statement and silenced the rest using a .hadolint.yaml file
- markdownlint complains about our PR template - it seems as if @NickLarsenNZ tried to fix this in April but changed the wrong markdownlint config file

While I was at it I updated various dependencies again...