### PR TITLE
Support the Tilt workflow on Darwin/macOS

### DIFF
--- a/template/default.nix
+++ b/template/default.nix
@@ -157,10 +157,6 @@ rec {
     # (see https://github.com/pre-commit/pre-commit-hooks?tab=readme-ov-file#trailing-whitespace).
     # So, remove the trailing newline already here to avoid that an
     # unnecessary change is shown in Git.
-    if [[ "$(uname)" == "Darwin" ]]; then
-      sed -i \"\" '$d' Cargo.nix
-    else
-      sed -i '$d' Cargo.nix
-    fi
+    ${pkgs.gnused}/bin/sed -i '$d' Cargo.nix
   '';
 }

--- a/template/default.nix
+++ b/template/default.nix
@@ -95,7 +95,6 @@ rec {
   dockerImage = pkgsLocal.dockerTools.streamLayeredImage {
     name = dockerName;
     tag = dockerTag;
-    #includeStorePaths = false;
     contents = [
       # Common debugging tools
       pkgsTarget.bashInteractive

--- a/template/default.nix
+++ b/template/default.nix
@@ -117,7 +117,7 @@ rec {
       Cmd = [ "run" ];
     };
   };
-  docker = pkgsLocal.linkFarm "listener-operator-docker" [
+  docker = pkgsLocal.linkFarm "${dockerImage.name}-docker" [
     {
       name = "load-image";
       path = dockerImage;


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/732.

Mostly, this requires us to explicitly request that the contents of the Docker image be built on Linux. I also took the opportunity to split out `pkgs` to clarify when we build stuff for the local vs target environment.

This requires you to have a remote Nix builder available that runs on Linux. See https://github.com/stackabletech/nix-docker-builder for how to set that up.

Linux users should be unaffected, for us `pkgsLocal = pkgsTarget = old pkgs`.