### PR TITLE
feat: Add Service on top of operators

### DIFF
--- a/template/deploy/helm/[[operator]]/templates/deployment.yaml.j2
+++ b/template/deploy/helm/[[operator]]/templates/deployment.yaml.j2
@@ -48,6 +48,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.annotations['internal.stackable.tech/image']
+            - name: OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPERATOR_SERVICE_NAME
+              value: {{ include "operator.fullname" . }}
             {{- if .Values.kubernetesClusterDomain }}
             - name: KUBERNETES_CLUSTER_DOMAIN
               value: {{ .Values.kubernetesClusterDomain | quote }}

--- a/template/deploy/helm/[[operator]]/templates/service.yaml
+++ b/template/deploy/helm/[[operator]]/templates/service.yaml
@@ -1,0 +1,19 @@
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  # Note(@sbernauer): We could also call the Service something like
+  # "product-operator-conversion-webhook". However, in the future we will have more webhooks, and
+  # it seems like an overkill to have a dedicated Service per webhook.
+  name: {{ include "operator.fullname" . }}
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
+spec:
+  selector: 
+    {{- include "operator.selectorLabels" . | nindent 6 }}
+  ports:
+    - name: conversion-webhook
+      protocol: TCP
+      port: 8443
+      targetPort: 8443

--- a/template/deploy/helm/[[operator]]/templates/service.yaml
+++ b/template/deploy/helm/[[operator]]/templates/service.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     {{- include "operator.labels" . | nindent 4 }}
 spec:
-  selector: 
+  selector:
     {{- include "operator.selectorLabels" . | nindent 6 }}
   ports:
     - name: conversion-webhook


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/642
Needed for https://github.com/stackabletech/operator-rs/pull/1066

This PR only adds a Service on top of the operator Pod. This is needed, so that k8s can call the conversion webhook.
IMHO we can add this right now and start using it later.
This unblocks merging https://github.com/stackabletech/operator-rs/pull/1066, as that PR needs to `OPERATOR_NAMESPACE` and `OPERATOR_SERVICE_NAME` env vars