### PR TITLE
chore: Bump pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,14 +15,14 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: 81e9f98ffd059efe8aa9c1b1a42e5cce61b640c6 # 1.35.1
+    rev: 79a6b2b1392eaf49cdd32ac4f14be1a809bbd8f7 # 1.37.1
     hooks:
       - id: yamllint
         types: [text]
         files: \.(yml|yaml)(\.j2)*$
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: 586c3ea3f51230da42bab657c6a32e9e66c364f0 # 0.44.0
+    rev: 192ad822316c3a22fb3d3cc8aa6eafa0b8488360 # 0.45.0
     hooks:
       - id: markdownlint
         types: [text]
@@ -38,7 +38,7 @@ repos:
   # If you do not, you will need to delete the cached ruff binary shown in the
   # error message
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 2c8dce6094fa2b4b668e74f694ca63ceffd38614 # 0.9.9
+    rev: 0b19ef1fd6ad680ed7752d6daba883ce1265a6de # 0.12.2
     hooks:
       # Run the linter.
       - id: ruff

--- a/README.adoc
+++ b/README.adoc
@@ -29,8 +29,7 @@ To remove files or directories that already exist in the target repositories the
 
 Anything that is listed here will be deleted from the target repositories.
 
-NOTE: Deletion is the last step that is performed, so if there is an overlap between files existing in the template folder and this setting, the files would not be rolled out, since they'd get deleted before creting the pull request.
-
+NOTE: Deletion is the last step that is performed, so if there is an overlap between files existing in the template folder and this setting, the files would not be rolled out, since they'd get deleted before creating the pull request.
 
 === Configuration
 

--- a/template/.pre-commit-config.yaml.j2
+++ b/template/.pre-commit-config.yaml.j2
@@ -36,7 +36,7 @@ repos:
   # If you do not, you will need to delete the cached ruff binary shown in the
   # error message
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: d19233b89771be2d89273f163f5edc5a39bbc34a # 0.11.12
+    rev: 0b19ef1fd6ad680ed7752d6daba883ce1265a6de # 0.12.2
     hooks:
       # Run the linter.
       - id: ruff-check


### PR DESCRIPTION
Part of https://github.com/stackabletech/operator-templating/issues/512