### PR TITLE
chore: Enable strict mode for yamllint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ repos:
     rev: 79a6b2b1392eaf49cdd32ac4f14be1a809bbd8f7 # 1.37.1
     hooks:
       - id: yamllint
+        args: ["--strict"]
         types: [text]
         files: \.(yml|yaml)(\.j2)*$
 

--- a/template/.github/workflows/build.yml.j2
+++ b/template/.github/workflows/build.yml.j2
@@ -155,7 +155,7 @@ jobs:
         with:
           key: clippy
           cache-all-crates: "true"
-        # TODO (@Techassi): Remove this step (unmaintained action, kinda useless step anyway)
+      # TODO (@Techassi): Remove this step (unmaintained action, kinda useless step anyway)
       - name: Run clippy action to produce annotations
         uses: giraffate/clippy-action@13b9d32482f25d29ead141b79e7e04e7900281e0 # v1.0.1
         env:
@@ -165,7 +165,7 @@ jobs:
           clippy_flags: --all-targets -- -D warnings
           reporter: 'github-pr-review'
           github_token: ${{ secrets.GITHUB_TOKEN }}
-        # TODO (@Techassi): Remove, done by pre-commit
+      # TODO (@Techassi): Remove, done by pre-commit
       - name: Run clippy manually without annotations
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -345,9 +345,9 @@ jobs:
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN_VERSION }}
           components: rustfmt
-        # This step checks if the current run was triggered by a push to a pr (or a pr being created).
-        # If this is the case it changes the version of this project in all Cargo.toml files to include the suffix
-        # "-pr<prnumber>" so that the published artifacts can be linked to this PR.
+      # This step checks if the current run was triggered by a push to a pr (or a pr being created).
+      # If this is the case it changes the version of this project in all Cargo.toml files to include the suffix
+      # "-pr<prnumber>" so that the published artifacts can be linked to this PR.
       - uses: stackabletech/cargo-install-action@main
         with:
           crate: cargo-edit

--- a/template/.github/workflows/integration-test.yml
+++ b/template/.github/workflows/integration-test.yml
@@ -3,8 +3,8 @@ name: Integration Test
 
 on:
   # schedule:
-    # At 00:00 on Sunday. See: https://crontab.guru/#0_0_*_*_0
-    # - cron: "0 0 * * 0"
+  #   # At 00:00 on Sunday. See: https://crontab.guru/#0_0_*_*_0
+  #   - cron: "0 0 * * 0"
   workflow_dispatch:
     inputs:
       test-mode:

--- a/template/.pre-commit-config.yaml.j2
+++ b/template/.pre-commit-config.yaml.j2
@@ -18,6 +18,7 @@ repos:
     rev: 79a6b2b1392eaf49cdd32ac4f14be1a809bbd8f7 # 1.37.1
     hooks:
       - id: yamllint
+        args: ["--strict"]
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: 192ad822316c3a22fb3d3cc8aa6eafa0b8488360 # 0.45.0


### PR DESCRIPTION
Came up in the rollout of #544 (and other recent changes), eg. in https://github.com/stackabletech/airflow-operator/pull/674.