### PR TITLE
ci(template): Add hint for the runner or profile to use

### DIFF
--- a/template/.github/workflows/integration-test.yml
+++ b/template/.github/workflows/integration-test.yml
@@ -16,7 +16,7 @@ on:
           - custom
       test-mode-input:
         description: |
-          The profile or the runner used. Eg: `amd64` or `smoke-latest` (see test/interu.yaml)
+          The profile or the runner used. Eg: `smoke-latest` or `amd64` (see test/interu.yaml)
         required: true
       test-suite:
         description: Name of the test-suite. Only used if test-mode is `custom`


### PR DESCRIPTION
I never know what to put here, and I imagine others will also be stumped.

_Disclaimer, I happen to know to look in test/interu.yaml (although, I couldn't remember where that was initially)._

<img width="338" height="490" alt="image" src="https://github.com/user-attachments/assets/ee17f5fc-de93-43f3-97d9-0abcf9824a35" />

I think this change makes things more intuitive (at the expense of some ugly UI layout):

<img width="339" height="528" alt="image" src="https://github.com/user-attachments/assets/51c176f0-ccaa-4749-8870-a9b9043e9c80" />
