### PR TITLE
tests: pass on --listener-class-preset to stackablectl

### DIFF
--- a/template/scripts/run-tests
+++ b/template/scripts/run-tests
@@ -292,7 +292,9 @@ def release_file(
                 logging.error(f"Failed to delete patched release file: {release_file}")
 
 
-def maybe_install_release(skip_release: bool, release_file: str, listener_class_preset: str) -> None:
+def maybe_install_release(
+    skip_release: bool, release_file: str, listener_class_preset: str
+) -> None:
     if skip_release:
         logging.debug("Skip release installation")
         return
@@ -303,7 +305,11 @@ def maybe_install_release(skip_release: bool, release_file: str, listener_class_
             "install",
             "--release-file",
             release_file,
-            *(["--listener-class-preset", listener_class_preset] if listener_class_preset else []),
+            *(
+                ["--listener-class-preset", listener_class_preset]
+                if listener_class_preset
+                else []
+            ),
             "tests",
         ]
         logging.debug(f"Running : {stackablectl_cmd}")


### PR DESCRIPTION
Tested on an OKD cluster in the HBase op with presets:

```
./scripts/run-tests \
--test-suite openshift \
--test kerberos_hbase-2.6.3_hdfs-latest-3.4.2_zookeeper-latest-3.9.4_krb5-1.21.1_listener-class-external-unstable_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-true \
--listener-class-preset stable-nodes
```

and without

```
./scripts/run-tests \
--test-suite openshift \
--test kerberos_hbase-2.6.3_hdfs-latest-3.4.2_zookeeper-latest-3.9.4_krb5-1.21.1_listener-class-external-unstable_kerberos-realm-PROD.MYCORP_kerberos-backend-mit_openshift-true
```

Listener classes were created as expected.