### PR TITLE
Added option to allow the user the option of not using crate2nix but the default Docker build process instead.

### DIFF
--- a/template/Tiltfile
+++ b/template/Tiltfile
@@ -6,12 +6,12 @@ registry = settings.get('default_registry', 'oci.stackable.tech/sandbox')
 default_registry(registry)
 
 # Configure which builder to use from config file, defaults to 'nix'
-builder = settings.get('builder', 'crate2nix')
+builder = settings.get('builder', 'nix')
 
 meta = read_json('nix/meta.json')
 operator_name = meta['operator']['name']
 
-if builder == 'crate2nix':
+if builder == 'nix':
     custom_build(
         registry + '/' + operator_name,
         'make regenerate-nix && nix-build . -A docker --argstr dockerName "${EXPECTED_REGISTRY}/' + operator_name + '" && ./result/load-image | docker load',


### PR DESCRIPTION
Not sure if this is feasible to use with Tilt due to fairly long build times, might be necessary to pause deployment of the resources in Tilt and manually triggering as and when needed.