### PR TITLE
Add final job for checks

### DIFF
--- a/template/.github/workflows/build.yaml.j2
+++ b/template/.github/workflows/build.yaml.j2
@@ -75,8 +75,6 @@ jobs:
 
   build-container-image:
     name: Build/Publish ${{ matrix.runner.arch }} Image
-    needs:
-      - cargo-udeps
     permissions:
       id-token: write
     strategy:
@@ -231,6 +229,7 @@ jobs:
     # Required Checks (in branch protections) in GitHub settings.
     name: Finished Build and Publish
     needs:
+      - cargo-udeps
       - openshift-preflight-check
       - publish-helm-chart
     runs-on: ubuntu-latest


### PR DESCRIPTION
In GitHub, we have some required checks on branch protection rules.
These are unfortunately selected by name.

We had two problems:
- Names of jobs are dynamic, so those ones can't be used as required checks
- We have more than one job we require (really, we require the workflow, but Github doesn't offer this possibility).