### PR TITLE
chore: Allow RUSTSEC-2024-0436 and kube-rs git repo

### DIFF
--- a/template/deny.toml
+++ b/template/deny.toml
@@ -24,6 +24,20 @@ ignore = [
     #
     # https://github.com/RustCrypto/RSA/issues/19 is the tracking issue
     "RUSTSEC-2023-0071",
+
+    # https://rustsec.org/advisories/RUSTSEC-2024-0436
+    # The "paste" crate is no longer maintained because the owner states that the implementation is
+    # finished. There are at least two (forked) alternatives which state to be maintained. They'd
+    # need to be vetted before a potential switch. Additionally, they'd need to be in a maintained
+    # state for a couple of years to provide any benefit over using "paste".
+    #
+    # This crate is only used in a single place in the xtask package inside the declarative
+    # "write_crd" macro. The impact of vulnerabilities, if any, should be fairly minimal.
+    #
+    # See thread: https://users.rust-lang.org/t/paste-alternatives/126787/4
+    #
+    # This can only be removed again if we decide to use a different crate.
+    "RUSTSEC-2024-0436",
 ]
 
 [bans]
@@ -67,6 +81,9 @@ license-files = [
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
+allow-git = [
+    "https://github.com/kube-rs/kube-rs",
+]
 
 [sources.allow-org]
 github = ["stackabletech"]


### PR DESCRIPTION
RUSTSEC-2024-0436 was already silenced in operator-rs, this PR copies it over to the source of truth.

Additionally, we sometimes need to pull in kube-rs as a git dependency, so we allow that.