### PR TITLE
fix: Deduplicate nix-shell inputs to fix "Argument list too long" error

### DIFF
--- a/template/shell.nix
+++ b/template/shell.nix
@@ -21,10 +21,10 @@ in pkgs.mkShell rec {
   ];
 
   # derivation runtime dependencies
-  buildInputs = pkgs.lib.concatMap (crate: crate.buildInputs) cargoDependencySet;
+  buildInputs = pkgs.lib.unique (pkgs.lib.concatMap (crate: crate.buildInputs) cargoDependencySet);
 
   # build time dependencies
-  nativeBuildInputs = pkgs.lib.concatMap (crate: crate.nativeBuildInputs) cargoDependencySet ++ (with pkgs; [
+  nativeBuildInputs = pkgs.lib.unique (pkgs.lib.concatMap (crate: crate.nativeBuildInputs) cargoDependencySet ++ (with pkgs; [
     beku
     docker
     gettext # for the proper envsubst
@@ -38,7 +38,7 @@ in pkgs.mkShell rec {
     # tilt already defined in default.nix
     which
     yq-go
-  ]);
+  ]));
 
   LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
   BINDGEN_EXTRA_CLANG_ARGS = "-I${pkgs.glibc.dev}/include -I${pkgs.clang}/resource-root/include";


### PR DESCRIPTION
Fixes
```bash
➜  secret-operator git:(main) nix-shell
error: executing shell '/nix/store/5p86w1968gs5abgqkj9wv5gccxpy253c-bash-interactive-5.3p3/bin/bash': Argument list too long
```

The buildInputs and nativeBuildInputs lists were constructed by concatMapping over all transitive crate dependencies without deduplication. Since hundreds of crates share the same native build inputs (Rust compiler, linker, pkg-config, etc.), identical store paths were repeated hundreds of times, bloating PATH and other environment variables beyond the kernel's ARG_MAX limit.

Wrapping both lists with pkgs.lib.unique eliminates the duplicates and brings the environment size back within limits.

PS: Generated using Claude
