### PR TITLE
chore: Update templated files for conversion webhook

### DIFF
--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -44,9 +44,11 @@ config:
 		cp -r deploy/config-spec/* "deploy/helm/${OPERATOR_NAME}/configs";\
 	fi
 
+# We generate a crds.yaml, so that the effect of code changes are visible.
+# The operator will take care of the CRD rollout itself.
 crds:
-	mkdir -p deploy/helm/"${OPERATOR_NAME}"/crds
-	cargo run --bin stackable-"${OPERATOR_NAME}" -- crd | yq eval '.metadata.annotations["helm.sh/resource-policy"]="keep"' - > "deploy/helm/${OPERATOR_NAME}/crds/crds.yaml"
+	mkdir -p extra
+	cargo run --bin stackable-"${OPERATOR_NAME}" -- crd > extra/crds.yaml
 
 chart-lint: compile-chart
 	docker run -it -v $(shell pwd):/build/helm-charts -w /build/helm-charts quay.io/helmpack/chart-testing:v3.5.0  ct lint --config deploy/helm/ct.yaml

--- a/template/Tiltfile
+++ b/template/Tiltfile
@@ -17,11 +17,6 @@ custom_build(
     outputs_image_ref_to='result/ref',
 )
 
-# Load the latest CRDs from Nix
-watch_file('result')
-if os.path.exists('result'):
-   k8s_yaml('result/crds.yaml')
-
 # We need to set the correct image annotation on the operator Deployment to use e.g.
 # oci.stackable.tech/sandbox/opa-operator:7y19m3d8clwxlv34v5q2x4p7v536s00g instead of
 # oci.stackable.tech/sandbox/opa-operator:0.0.0-dev (which does not exist)
@@ -35,18 +30,12 @@ helm_values = settings.get('helm_values', None)
 
 helm_override_image_repository = 'image.repository=' + registry + '/' + operator_name
 
-# Exclude stale CRDs from Helm chart, and apply the rest
-helm_crds, helm_non_crds = filter_yaml(
-   helm(
-      'deploy/helm/' + operator_name,
-      name=operator_name,
-      namespace="stackable-operators",
-      set=[
-         helm_override_image_repository,
-      ],
-      values=helm_values,
-   ),
-   api_version = "^apiextensions\\.k8s\\.io/.*$",
-   kind = "^CustomResourceDefinition$",
-)
-k8s_yaml(helm_non_crds)
+k8s_yaml(helm(
+   'deploy/helm/' + operator_name,
+   name=operator_name,
+   namespace="stackable-operators",
+   set=[
+      helm_override_image_repository,
+   ],
+   values=helm_values,
+))

--- a/template/deploy/helm/[[operator]]/templates/deployment.yaml.j2
+++ b/template/deploy/helm/[[operator]]/templates/deployment.yaml.j2
@@ -22,6 +22,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
+        {{- if .Values.maintenance.customResourceDefinitions.maintain }}
+        webhook.stackable.tech/conversion: enabled
+        {{- end }}
         {{- include "operator.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.image.pullSecrets }}
@@ -79,7 +82,9 @@ spec:
             - name: KUBERNETES_CLUSTER_DOMAIN
               value: {{ .Values.kubernetesClusterDomain | quote }}
             {{- end }}
+
             {{- include "telemetry.envVars" . | nindent 12 }}
+            {{- include "maintenance.envVars" . | nindent 12 }}
 {[% if operator.product_string in ['opa'] %}]
             - name: OPA_BUNDLE_BUILDER_CLUSTERROLE
               value: {{ include "operator.fullname" . }}-opa-bundle-builder-clusterrole

--- a/template/deploy/helm/[[operator]]/templates/service.yaml
+++ b/template/deploy/helm/[[operator]]/templates/service.yaml
@@ -11,7 +11,10 @@ metadata:
     {{- include "operator.labels" . | nindent 4 }}
 spec:
   selector:
-    {{- include "operator.selectorLabels" . | nindent 6 }}
+    {{- if .Values.maintenance.customResourceDefinitions.maintain }}
+    webhook.stackable.tech/conversion: enabled
+    {{- end }}
+    {{- include "operator.selectorLabels" . | nindent 4 }}
   ports:
     - name: conversion-webhook
       protocol: TCP


### PR DESCRIPTION
This brings in changes from https://github.com/stackabletech/issues/issues/808 so that there is no drift between templating and downstream operators anymore.