### PR TITLE
template(ci): Fix operator version extraction

### DIFF
--- a/template/.github/workflows/build.yaml.j2
+++ b/template/.github/workflows/build.yaml.j2
@@ -139,7 +139,7 @@ jobs:
           set -euo pipefail
           [ -n "$GITHUB_DEBUG" ] && set -x
 
-          CURRENT_VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[0].version')
+          CURRENT_VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "stackable-{[ operator.name }]") | .version')
 
           if [ "$GITHUB_EVENT_NAME" == 'pull_request' ]; then
             # Include a PR suffix if this workflow is triggered by a PR


### PR DESCRIPTION
Previously, we assumed that the first package is always the operator package. This is not true, for example this resulted in a wrong version here: https://github.com/stackabletech/secret-operator/actions/runs/22309511940/attempts/1.

To fix this, we filter/select the package by operator name instead of hard-coding index `0`.