### PR TITLE
chore(template): Use --no-deps in pre-commit hook

### DIFF
--- a/template/.pre-commit-config.yaml.j2
+++ b/template/.pre-commit-config.yaml.j2
@@ -89,7 +89,7 @@ repos:
       - id: cargo-doc
         name: cargo-doc
         language: system
-        entry: cargo doc --document-private-items
+        entry: cargo doc --no-deps --document-private-items
         stages: [pre-commit, pre-merge-commit]
         pass_filenames: false
         files: \.rs$|Cargo\.(toml|lock)


### PR DESCRIPTION
This only generates the local documentation (which is the thing we want to ensure is valid) instead of generating the docs for _everything_.