### PR TITLE
ci(template): Skip various jobs/steps if coming from a fork

### DIFF
--- a/.github/workflows/pr_pre-commit.yml
+++ b/.github/workflows/pr_pre-commit.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-      - uses: stackabletech/actions/run-pre-commit@c34dbb4f27b274736c7d2edc6f6f30a03d03edf5 # v0.12.2
+      - uses: stackabletech/actions/run-pre-commit@9848c5593dff4793aacba240116a648c02f20fa4 # v0.13.1
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           hadolint: ${{ env.HADOLINT_VERSION }}

--- a/template/.github/workflows/build.yaml.j2
+++ b/template/.github/workflows/build.yaml.j2
@@ -174,6 +174,7 @@ jobs:
           container-file: docker/Dockerfile
 
       - name: Publish Container Image
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: stackabletech/actions/publish-image@babe44d7b1db87f8e7731c011151d22a8a374191 # v0.12.0
         with:
           image-registry-uri: oci.stackable.tech
@@ -185,7 +186,10 @@ jobs:
 
   publish-index-manifest:
     name: Publish/Sign ${{ needs.build-container-image.outputs.operator-version }} Index
-    if: (github.event_name != 'merge_group') && needs.detect-changes.outputs.detected == 'true'
+    if: |
+      (github.event_name != 'merge_group')
+      && needs.detect-changes.outputs.detected == 'true'
+      && !github.event.pull_request.head.repo.fork
     needs:
       - detect-changes
       - build-container-image
@@ -209,7 +213,9 @@ jobs:
 
   publish-helm-chart:
     name: Package/Publish ${{ needs.build-container-image.outputs.operator-version }} Helm Chart
-    if: (github.event_name != 'merge_group') && needs.detect-changes.outputs.detected == 'true'
+    if: |
+      (github.event_name != 'merge_group')
+      && needs.detect-changes.outputs.detected == 'true'
     needs:
       - detect-changes
       - build-container-image
@@ -233,10 +239,14 @@ jobs:
           chart-directory: deploy/helm/${{ env.OPERATOR_NAME }}
           chart-version: ${{ needs.build-container-image.outputs.operator-version }}
           app-version: ${{ needs.build-container-image.outputs.operator-version }}
+          publish-and-sign: ${{ !github.event.pull_request.head.repo.fork }}
 
   openshift-preflight-check:
     name: Run OpenShift Preflight Check for ${{ needs.build-container-image.outputs.operator-version }}-${{ matrix.arch }}
-    if: (github.event_name != 'merge_group') && needs.detect-changes.outputs.detected == 'true'
+    if: |
+      (github.event_name != 'merge_group')
+      && needs.detect-changes.outputs.detected == 'true'
+      && !github.event.pull_request.head.repo.fork
     needs:
       - detect-changes
       - build-container-image
@@ -272,7 +282,11 @@ jobs:
 
   notify:
     name: Failure Notification
-    if: (failure() || github.run_attempt > 1) && github.event_name != 'merge_group' && needs.detect-changes.outputs.detected == 'true'
+    if: |
+      (failure() || github.run_attempt > 1)
+      && github.event_name != 'merge_group'
+      && needs.detect-changes.outputs.detected == 'true'
+      && !github.event.pull_request.head.repo.fork
     needs:
       - detect-changes
       - build-container-image

--- a/template/.github/workflows/build.yaml.j2
+++ b/template/.github/workflows/build.yaml.j2
@@ -48,7 +48,7 @@ jobs:
 
       - name: Check for changed files
         id: check
-        uses: stackabletech/actions/detect-changes@babe44d7b1db87f8e7731c011151d22a8a374191 # v0.12.0
+        uses: stackabletech/actions/detect-changes@9848c5593dff4793aacba240116a648c02f20fa4 # v0.13.1
         with:
           patterns: |
             - '.github/workflows/build.yaml'
@@ -166,7 +166,7 @@ jobs:
 
       - name: Build Container Image
         id: build
-        uses: stackabletech/actions/build-container-image@babe44d7b1db87f8e7731c011151d22a8a374191 # v0.12.0
+        uses: stackabletech/actions/build-container-image@9848c5593dff4793aacba240116a648c02f20fa4 # v0.13.1
         with:
           image-name: ${{ env.OPERATOR_NAME }}
           image-index-manifest-tag: ${{ steps.version.outputs.OPERATOR_VERSION }}
@@ -175,7 +175,7 @@ jobs:
 
       - name: Publish Container Image
         if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: stackabletech/actions/publish-image@babe44d7b1db87f8e7731c011151d22a8a374191 # v0.12.0
+        uses: stackabletech/actions/publish-image@9848c5593dff4793aacba240116a648c02f20fa4 # v0.13.1
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -203,7 +203,7 @@ jobs:
           persist-credentials: false
 
       - name: Publish and Sign Image Index
-        uses: stackabletech/actions/publish-image-index-manifest@babe44d7b1db87f8e7731c011151d22a8a374191 # v0.12.0
+        uses: stackabletech/actions/publish-image-index-manifest@9848c5593dff4793aacba240116a648c02f20fa4 # v0.13.1
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -230,7 +230,7 @@ jobs:
           submodules: recursive
 
       - name: Package, Publish, and Sign Helm Chart
-        uses: stackabletech/actions/publish-helm-chart@babe44d7b1db87f8e7731c011151d22a8a374191 # v0.12.0
+        uses: stackabletech/actions/publish-helm-chart@9848c5593dff4793aacba240116a648c02f20fa4 # v0.13.1
         with:
           chart-registry-uri: oci.stackable.tech
           chart-registry-username: robot$sdp-charts+github-action-build
@@ -260,7 +260,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run OpenShift Preflight Check
-        uses: stackabletech/actions/run-openshift-preflight@babe44d7b1db87f8e7731c011151d22a8a374191 # v0.12.0
+        uses: stackabletech/actions/run-openshift-preflight@9848c5593dff4793aacba240116a648c02f20fa4 # v0.13.1
         with:
           image-index-uri: oci.stackable.tech/sdp/${{ env.OPERATOR_NAME }}:${{ needs.build-container-image.outputs.operator-version }}
           image-architecture: ${{ matrix.arch }}
@@ -300,7 +300,7 @@ jobs:
           persist-credentials: false
 
       - name: Send Notification
-        uses: stackabletech/actions/send-slack-notification@babe44d7b1db87f8e7731c011151d22a8a374191 # v0.12.0
+        uses: stackabletech/actions/send-slack-notification@9848c5593dff4793aacba240116a648c02f20fa4 # v0.13.1
         with:
           publish-helm-chart-result: ${{ needs.publish-helm-chart.result }}
           publish-manifests-result: ${{ needs.publish-index-manifest.result }}

--- a/template/.github/workflows/integration-test.yml
+++ b/template/.github/workflows/integration-test.yml
@@ -41,7 +41,7 @@ jobs:
       # TODO: Enable the scheduled runs which hard-code what profile to use
       - name: Run Integration Test
         id: test
-        uses: stackabletech/actions/run-integration-test@29bea1b451c0c2e994bd495969286f95bf49ed6a # v0.11.0
+        uses: stackabletech/actions/run-integration-test@9848c5593dff4793aacba240116a648c02f20fa4 # v0.13.1
         with:
           replicated-api-token: ${{ secrets.REPLICATED_API_TOKEN }}
           test-mode-input: ${{ inputs.test-mode-input }}
@@ -51,7 +51,7 @@ jobs:
 
       - name: Send Notification
         if: ${{ failure() || github.run_attempt > 1 }}
-        uses: stackabletech/actions/send-slack-notification@29bea1b451c0c2e994bd495969286f95bf49ed6a # v0.11.0
+        uses: stackabletech/actions/send-slack-notification@9848c5593dff4793aacba240116a648c02f20fa4 # v0.13.1
         with:
           slack-token: ${{ secrets.SLACK_INTEGRATION_TEST_TOKEN }}
           failed-tests: ${{ steps.test.outputs.failed-tests }}

--- a/template/.github/workflows/pr_pre-commit.yaml.j2
+++ b/template/.github/workflows/pr_pre-commit.yaml.j2
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
           submodules: recursive
           fetch-depth: 0
-      - uses: stackabletech/actions/run-pre-commit@29bea1b451c0c2e994bd495969286f95bf49ed6a # v0.11.0
+      - uses: stackabletech/actions/run-pre-commit@9848c5593dff4793aacba240116a648c02f20fa4 # v0.13.1
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           rust: ${{ env.RUST_TOOLCHAIN_VERSION }}


### PR DESCRIPTION
Came up in https://github.com/stackabletech/airflow-operator/actions/runs/23501145508/job/68397977342.

> [!NOTE]
> This PR bumps `stackabletech/actions` to v0.13.1 across the board, which supports skipping publishing and signing Helm Charts.

With this PR, various jobs and steps are skipped if the PR is raised from a fork by external contributors. The fork doesn't (and shouldn't) have access to various credentials/secrets. As such, some of our CI tasks cannot be run.