### PR TITLE
chore: Ignore RUSTSEC-2026-0097 in deny.toml

### DIFF
--- a/template/deny.toml
+++ b/template/deny.toml
@@ -38,6 +38,13 @@ ignore = [
     #
     # This can only be removed again if we decide to use a different crate.
     "RUSTSEC-2024-0436",
+
+    # https://rustsec.org/advisories/RUSTSEC-2026-0097
+    # rand 0.8.5 is unsound when log+thread_rng features are enabled and a custom logger calls rand::rng().
+    #
+    # This version is pulled in transitively via num-bigint-dig -> rsa -> stackable-certs and cannot be
+    # updated until the upstream rsa crate bumps its rand dependency.
+    "RUSTSEC-2026-0097",
 ]
 
 [bans]


### PR DESCRIPTION
Ignore RUSTSEC-2026-0097 when calling `cargo deny check advisories`

I have not checked if this is an exploitable vulnerability.