### PR TITLE
feat: Generate SLSA provenance for operator images

### DIFF
--- a/.github/workflows/pr_prek.yml
+++ b/.github/workflows/pr_prek.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-      - uses: stackabletech/actions/run-prek@bb86a79a5ab73726d4f047f07452c3307ff0b300 # v0.15.0
+      - uses: stackabletech/actions/run-prek@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           hadolint: ${{ env.HADOLINT_VERSION }}

--- a/template/.github/workflows/build.yaml.j2
+++ b/template/.github/workflows/build.yaml.j2
@@ -205,6 +205,9 @@ jobs:
     permissions:
       id-token: write
     runs-on: ubuntu-latest
+    outputs:
+      oci-index-digest: ${{ steps.publish-oci.outputs.image-index-manifest-digest }}
+      quay-index-digest: ${{ steps.publish-quay.outputs.image-index-manifest-digest }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -212,6 +215,7 @@ jobs:
           persist-credentials: false
 
       - name: Publish and Sign Image Index to oci.stackable.tech
+        id: publish-oci
         uses: stackabletech/actions/publish-image-index-manifest@a14cbd08d9e034e2361ea9205b32aff0491885db # v0.15.0
         with:
           image-registry-uri: oci.stackable.tech
@@ -221,6 +225,7 @@ jobs:
           image-index-manifest-tag: ${{ needs.build-container-image.outputs.operator-version }}
 
       - name: Publish and Sign Image Index to quay.io
+        id: publish-quay
         uses: stackabletech/actions/publish-image-index-manifest@a14cbd08d9e034e2361ea9205b32aff0491885db # v0.15.0
         with:
           image-registry-uri: quay.io
@@ -228,6 +233,64 @@ jobs:
           image-registry-password: ${{ secrets.QUAY_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
           image-repository: stackable/sdp/${{ env.OPERATOR_NAME }}
           image-index-manifest-tag: ${{ needs.build-container-image.outputs.operator-version }}
+
+  # Generate SLSA build provenance for the multi-arch image index and attach it
+  # to the published image in each registry. The reusable workflow signs the
+  # provenance with keyless signing (GitHub Actions as the OIDC identity) and
+  # pushes the attestation next to the image.
+  provenance-oci:
+    name: Generate Provenance for ${{ needs.build-container-image.outputs.operator-version }} (oci.stackable.tech)
+    if: |
+      (github.event_name != 'merge_group')
+      && needs.detect-changes.outputs.detected == 'true'
+      && !github.event.pull_request.head.repo.fork
+    needs:
+      - detect-changes
+      - build-container-image
+      - publish-index-manifest
+    permissions:
+      actions: read # detect the build workflow that generated the image
+      id-token: write # mint the OIDC token for keyless signing
+      packages: write # needed until https://github.com/slsa-framework/slsa-github-generator/issues/1257 is resolved
+    # MUST be referenced by a @vX.Y.Z tag (not a SHA), otherwise the reusable
+    # workflow cannot verify its own provenance.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    with:
+      # The 'env' context is not available in job-level 'with' inputs of
+      # reusable workflow calls (unlike step-level 'with'), so OPERATOR_NAME
+      # can't be used here and the operator name is templated in directly.
+      image: oci.stackable.tech/sdp/{[ operator.name }]
+      digest: ${{ needs.publish-index-manifest.outputs.oci-index-digest }}
+      registry-username: robot$sdp+github-action-build
+    secrets:
+      registry-password: ${{ secrets.HARBOR_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
+
+  provenance-quay:
+    name: Generate Provenance for ${{ needs.build-container-image.outputs.operator-version }} (quay.io)
+    if: |
+      (github.event_name != 'merge_group')
+      && needs.detect-changes.outputs.detected == 'true'
+      && !github.event.pull_request.head.repo.fork
+    needs:
+      - detect-changes
+      - build-container-image
+      - publish-index-manifest
+    permissions:
+      actions: read # detect the build workflow that generated the image
+      id-token: write # mint the OIDC token for keyless signing
+      packages: write # needed until https://github.com/slsa-framework/slsa-github-generator/issues/1257 is resolved
+    # MUST be referenced by a @vX.Y.Z tag (not a SHA), otherwise the reusable
+    # workflow cannot verify its own provenance.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    with:
+      # The 'env' context is not available in job-level 'with' inputs of
+      # reusable workflow calls (unlike step-level 'with'), so OPERATOR_NAME
+      # can't be used here and the operator name is templated in directly.
+      image: quay.io/stackable/sdp/{[ operator.name }]
+      digest: ${{ needs.publish-index-manifest.outputs.quay-index-digest }}
+      registry-username: stackable+robot_sdp_github_action_build
+    secrets:
+      registry-password: ${{ secrets.QUAY_ROBOT_SDP_GITHUB_ACTION_BUILD_SECRET }}
 
   publish-helm-chart:
     name: Package/Publish ${{ needs.build-container-image.outputs.operator-version }} Helm Chart
@@ -328,6 +391,8 @@ jobs:
       - detect-changes
       - build-container-image
       - publish-index-manifest
+      - provenance-oci
+      - provenance-quay
       - publish-helm-chart
     runs-on: ubuntu-latest
     steps:

--- a/template/.github/workflows/build.yaml.j2
+++ b/template/.github/workflows/build.yaml.j2
@@ -48,7 +48,7 @@ jobs:
 
       - name: Check for changed files
         id: check
-        uses: stackabletech/actions/detect-changes@a14cbd08d9e034e2361ea9205b32aff0491885db # v0.15.0
+        uses: stackabletech/actions/detect-changes@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           patterns: |
             - '.github/workflows/build.yaml'
@@ -164,7 +164,7 @@ jobs:
 
       - name: Build Container Image
         id: build
-        uses: stackabletech/actions/build-container-image@a14cbd08d9e034e2361ea9205b32aff0491885db # v0.15.0
+        uses: stackabletech/actions/build-container-image@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           image-name: ${{ env.OPERATOR_NAME }}
           image-index-manifest-tag: ${{ steps.version.outputs.OPERATOR_VERSION }}
@@ -173,7 +173,7 @@ jobs:
 
       - name: Publish Container Image to oci.stackable.tech
         if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: stackabletech/actions/publish-image@a14cbd08d9e034e2361ea9205b32aff0491885db # v0.15.0
+        uses: stackabletech/actions/publish-image@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -184,7 +184,7 @@ jobs:
 
       - name: Publish Container Image to quay.io
         if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: stackabletech/actions/publish-image@a14cbd08d9e034e2361ea9205b32aff0491885db # v0.15.0
+        uses: stackabletech/actions/publish-image@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           image-registry-uri: quay.io
           image-registry-username: stackable+robot_sdp_github_action_build
@@ -216,7 +216,7 @@ jobs:
 
       - name: Publish and Sign Image Index to oci.stackable.tech
         id: publish-oci
-        uses: stackabletech/actions/publish-image-index-manifest@a14cbd08d9e034e2361ea9205b32aff0491885db # v0.15.0
+        uses: stackabletech/actions/publish-image-index-manifest@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -226,7 +226,7 @@ jobs:
 
       - name: Publish and Sign Image Index to quay.io
         id: publish-quay
-        uses: stackabletech/actions/publish-image-index-manifest@a14cbd08d9e034e2361ea9205b32aff0491885db # v0.15.0
+        uses: stackabletech/actions/publish-image-index-manifest@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           image-registry-uri: quay.io
           image-registry-username: stackable+robot_sdp_github_action_build
@@ -311,7 +311,7 @@ jobs:
           submodules: recursive
 
       - name: Package, Publish, and Sign Helm Chart to oci.stackable.tech
-        uses: stackabletech/actions/publish-helm-chart@a14cbd08d9e034e2361ea9205b32aff0491885db # v0.15.0
+        uses: stackabletech/actions/publish-helm-chart@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           chart-registry-uri: oci.stackable.tech
           chart-registry-username: robot$sdp-charts+github-action-build
@@ -323,7 +323,7 @@ jobs:
           publish-and-sign: ${{ !github.event.pull_request.head.repo.fork }}
 
       - name: Package, Publish, and Sign Helm Chart to quay.io
-        uses: stackabletech/actions/publish-helm-chart@a14cbd08d9e034e2361ea9205b32aff0491885db # v0.15.0
+        uses: stackabletech/actions/publish-helm-chart@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           chart-registry-uri: quay.io
           chart-registry-username: stackable+robot_sdp_charts_github_action_build
@@ -354,13 +354,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run OpenShift Preflight Check for oci.stackable.tech
-        uses: stackabletech/actions/run-openshift-preflight@a14cbd08d9e034e2361ea9205b32aff0491885db # v0.15.0
+        uses: stackabletech/actions/run-openshift-preflight@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           image-index-uri: oci.stackable.tech/sdp/${{ env.OPERATOR_NAME }}:${{ needs.build-container-image.outputs.operator-version }}
           image-architecture: ${{ matrix.arch }}
 
       - name: Run OpenShift Preflight Check for quay.io
-        uses: stackabletech/actions/run-openshift-preflight@a14cbd08d9e034e2361ea9205b32aff0491885db # v0.15.0
+        uses: stackabletech/actions/run-openshift-preflight@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           image-index-uri: quay.io/stackable/sdp/${{ env.OPERATOR_NAME }}:${{ needs.build-container-image.outputs.operator-version }}
           image-architecture: ${{ matrix.arch }}
@@ -402,7 +402,7 @@ jobs:
           persist-credentials: false
 
       - name: Send Notification
-        uses: stackabletech/actions/send-slack-notification@a14cbd08d9e034e2361ea9205b32aff0491885db # v0.15.0
+        uses: stackabletech/actions/send-slack-notification@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           publish-helm-chart-result: ${{ needs.publish-helm-chart.result }}
           publish-manifests-result: ${{ needs.publish-index-manifest.result }}

--- a/template/.github/workflows/integration-test.yml
+++ b/template/.github/workflows/integration-test.yml
@@ -43,7 +43,7 @@ jobs:
       # TODO: Enable the scheduled runs which hard-code what profile to use
       - name: Run Integration Test
         id: test
-        uses: stackabletech/actions/run-integration-test@a14cbd08d9e034e2361ea9205b32aff0491885db # v0.15.0
+        uses: stackabletech/actions/run-integration-test@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           replicated-api-token: ${{ secrets.REPLICATED_API_TOKEN }}
           test-mode-input: ${{ inputs.test-mode-input }}
@@ -53,7 +53,7 @@ jobs:
 
       - name: Send Notification
         if: ${{ failure() || github.run_attempt > 1 }}
-        uses: stackabletech/actions/send-slack-notification@a14cbd08d9e034e2361ea9205b32aff0491885db # v0.15.0
+        uses: stackabletech/actions/send-slack-notification@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           slack-token: ${{ secrets.SLACK_INTEGRATION_TEST_TOKEN }}
           failed-tests: ${{ steps.test.outputs.failed-tests }}

--- a/template/.github/workflows/pr_prek.yaml.j2
+++ b/template/.github/workflows/pr_prek.yaml.j2
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
           submodules: recursive
           fetch-depth: 0
-      - uses: stackabletech/actions/run-prek@a14cbd08d9e034e2361ea9205b32aff0491885db # v0.15.0
+      - uses: stackabletech/actions/run-prek@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:
           rust: ${{ env.RUST_TOOLCHAIN_VERSION }}
           hadolint: ${{ env.HADOLINT_VERSION }}


### PR DESCRIPTION
Bumped `stackabletech/actions` from v0.15.0 to v0.16.0 so the digest output is provided.

Add `provenance-oci` and `provenance-quay` jobs to the templated build workflow. Both call the slsa-github-generator container workflow against the multi-arch image index digest published to each registry, attaching signed SLSA build provenance to the image.

Optional extra information, feel free to ignore:
I added SLSA provenance to our fork of SecObserve already in a similar fashion, here is the workflow run:
https://github.com/stackabletech/SecObserve/actions/runs/28184881580

Here is an example of how to manually inspect the SLSA provenance attestation for an image:
```
cosign download attestation oci.stackable.tech/stackable/secobserve-backend@sha256:66972afe0b57d3747d892a2887c7f872176e7cd824d2cdfff0dd851ba3ce6eda
de8a844526f3 | jq -r '.payload' | base64 -d | jq 'select(.predicateType=="https://slsa.dev/provenance/v0.2") | .predicate.invocation'
```

Or using [slsa-verifier](https://github.com/slsa-framework/slsa-verifier):
```
slsa-verifier verify-image oci.stackable.tech/stackable/secobserve-backend@sha256:66972afe0b57d3747d892a2887c7f872176e7cd824d2cdfff0dd851ba3ce6eda --source-uri github.com/stackabletech/SecObserve
```

It's basically a signed JSON document that provides a ton of metadata about the image build. The attestation is done by an isolated job that runs `https://github.com/slsa-framework/slsa-github-generator/blob/main/.github/workflows/generator_container_slsa3.yml`, so it's an independent "witness" that can't be manipulated (this means we achieve [SLSA level 3](https://slsa.dev/spec/v0.1/levels)). Luckily it's pretty easy to do since we use GitHub actions.