### PR TITLE
Ci hardening

### DIFF
--- a/.github/workflows/generate_prs.yml
+++ b/.github/workflows/generate_prs.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: cachix/install-nix-action@fd24c48048070c1be9acd18c9d369a83f0fe94d7 # v31.8.1
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
       - name: Install Ansible
         env:
           DEBIAN_FRONTEND: noninteractive
@@ -78,15 +78,14 @@ jobs:
       - name: Install jinja2
         run: pip install -r requirements.txt
 
-      # Create commit message and run the playbook
+      # Create commit message depending on whether this is run manually or due to a scheduled run
       - name: Run playbook
         env:
           CUSTOM_PR_TITLE: ${{ inputs.custom-pr-title }}
           GH_ACCESS_TOKEN: ${{ secrets.gh_access_token }}
           REPOSITORY: ${{ matrix.repository }}
-          DRY_RUN_FLAGS: ${{ (github.event_name != 'schedule' && inputs.dry-run != false) && '--tags=local' || '' }}
-          # Safely pass inputs/context via environment variables to prevent injection
-          INPUT_MESSAGE: ${{ github.event.inputs.message }}
+          DRY_RUN_FLAGS: ${{ inputs.dry-run && '--tags=local' || '' }}
+          INPUT_MESSAGE: ${{ inputs.message }}
           SENDER_LOGIN: ${{ github.event.sender.login }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
@@ -98,7 +97,7 @@ jobs:
             REASON="$INPUT_MESSAGE"
           fi
 
-          # Encode parameters safely using jq, without serializing the GH_ACCESS_TOKEN
+          # Encode parameters using jq, without serializing the GH_ACCESS_TOKEN
           jq -n \
             --arg commit_hash "$GITHUB_SHA" \
             --arg author "$AUTHOR" \
@@ -109,4 +108,6 @@ jobs:
             '{commit_hash: $commit_hash, author: $author, reason: $reason, custom_pr_title: $custom_pr_title, base_dir: $base_dir, shard_repositories: [$repository]} | with_entries(select(.value != null and .value != ""))' > vars.json
 
           # Run the Ansible playbook. The token is read directly from the GH_ACCESS_TOKEN environment variable.
+          # $DRY_RUN_FLAGS is intentionally unquoted (empty or one fixed flag)
+          # shellcheck disable=SC2086
           ansible-playbook playbook/playbook.yaml --extra-vars "@vars.json" $DRY_RUN_FLAGS

--- a/.github/workflows/generate_prs.yml
+++ b/.github/workflows/generate_prs.yml
@@ -25,6 +25,8 @@ permissions: {}
 jobs:
   create-prs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
       matrix:
@@ -48,7 +50,7 @@ jobs:
           - trino-operator
           - zookeeper-operator
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - uses: cachix/install-nix-action@fd24c48048070c1be9acd18c9d369a83f0fe94d7 # v31.8.1
@@ -76,33 +78,35 @@ jobs:
       - name: Install jinja2
         run: pip install -r requirements.txt
 
-      # Create commit message depending on whether this is run manually or due to a scheduled run
-      - name: Set commit message for manual dispatch
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        env:
-          REASON: ${{ github.event.inputs.message }}
-          AUTHOR: ${{ github.event.sender.login }}
-        run: |
-          echo "AUTHOR=$AUTHOR" >> "$GITHUB_ENV"
-          echo "REASON=$REASON" >> "$GITHUB_ENV"
-      - name: Set commit message for schedule
-        if: ${{ github.event_name == 'schedule' }}
-        run: |
-          echo "AUTHOR=stackabletech/developers"
-          echo "REASON=Daily run triggered" >> "$GITHUB_ENV"
-
+      # Create commit message and run the playbook
       - name: Run playbook
         env:
           CUSTOM_PR_TITLE: ${{ inputs.custom-pr-title }}
           GH_ACCESS_TOKEN: ${{ secrets.gh_access_token }}
           REPOSITORY: ${{ matrix.repository }}
-          # tags local excludes all actions that actually generate PRs
-          DRY_RUN_FLAGS: ${{ inputs.dry-run && '--tags=local' || '' }}
-        # shellsheck disable=SC2086
+          DRY_RUN_FLAGS: ${{ (github.event_name != 'schedule' && inputs.dry-run != false) && '--tags=local' || '' }}
+          # Safely pass inputs/context via environment variables to prevent injection
+          INPUT_MESSAGE: ${{ github.event.inputs.message }}
+          SENDER_LOGIN: ${{ github.event.sender.login }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          echo '{}' | jq '{commit_hash: $ENV.GITHUB_SHA, author: $ENV.AUTHOR, reason: $ENV.REASON, custom_pr_title: $ENV.CUSTOM_PR_TITLE, base_dir: $pwd, gh_access_token: $ENV.GH_ACCESS_TOKEN, shard_repositories: [$ENV.REPOSITORY]} | with_entries(select(.value != null and .value != ""))' --arg pwd "$(pwd)" > vars.json
-          # $DRY_RUN_FLAGS is intentionally not quoted, since we need to avoid
-          # passing an argument if we're not in dry mode.
-          # This is safe, since it always has one of two hard-coded values.
-          # shellcheck disable=SC2086
+          if [ "$EVENT_NAME" = "schedule" ]; then
+            AUTHOR="stackabletech/developers"
+            REASON="Weekly run triggered"
+          else
+            AUTHOR="$SENDER_LOGIN"
+            REASON="$INPUT_MESSAGE"
+          fi
+
+          # Encode parameters safely using jq, without serializing the GH_ACCESS_TOKEN
+          jq -n \
+            --arg commit_hash "$GITHUB_SHA" \
+            --arg author "$AUTHOR" \
+            --arg reason "$REASON" \
+            --arg custom_pr_title "$CUSTOM_PR_TITLE" \
+            --arg base_dir "$(pwd)" \
+            --arg repository "$REPOSITORY" \
+            '{commit_hash: $commit_hash, author: $author, reason: $reason, custom_pr_title: $custom_pr_title, base_dir: $base_dir, shard_repositories: [$repository]} | with_entries(select(.value != null and .value != ""))' > vars.json
+
+          # Run the Ansible playbook. The token is read directly from the GH_ACCESS_TOKEN environment variable.
           ansible-playbook playbook/playbook.yaml --extra-vars "@vars.json" $DRY_RUN_FLAGS

--- a/.github/workflows/generate_prs.yml
+++ b/.github/workflows/generate_prs.yml
@@ -106,7 +106,7 @@ jobs:
             --arg author "$AUTHOR" \
             --arg reason "$REASON" \
             --arg custom_pr_title "$CUSTOM_PR_TITLE" \
-            --arg base_dir "$(pwd)" \
+            --arg base_dir "${PWD}" \
             --arg repository "$REPOSITORY" \
             '{commit_hash: $commit_hash, author: $author, reason: $reason, custom_pr_title: $custom_pr_title, base_dir: $base_dir, shard_repositories: [$repository]} | with_entries(select(.value != null and .value != ""))' > vars.json
 

--- a/.github/workflows/generate_prs.yml
+++ b/.github/workflows/generate_prs.yml
@@ -58,7 +58,7 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt update &&  \
+          sudo apt update && \
           sudo apt install -y software-properties-common && \
           sudo apt-add-repository ppa:ansible/ansible -y && \
           sudo apt install -y ansible
@@ -92,9 +92,12 @@ jobs:
           if [ "$EVENT_NAME" = "schedule" ]; then
             AUTHOR="stackabletech/developers"
             REASON="Weekly run triggered"
-          else
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             AUTHOR="$SENDER_LOGIN"
             REASON="$INPUT_MESSAGE"
+          else
+            echo "Unexpected event name '$EVENT_NAME'; expected 'schedule' or 'workflow_dispatch'"
+            exit 1
           fi
 
           # Encode parameters using jq, without serializing the GH_ACCESS_TOKEN

--- a/.github/workflows/pr_prek.yml
+++ b/.github/workflows/pr_prek.yml
@@ -12,8 +12,10 @@ permissions: {}
 jobs:
   prek:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/playbook/playbook.yaml
+++ b/playbook/playbook.yaml
@@ -2,6 +2,8 @@
 - name: Synchronize operator template files with operator repositories
   hosts: localhost
   connection: local
+  vars:
+    gh_access_token: "{{ lookup('env', 'GH_ACCESS_TOKEN') }}"
 
   tasks:
     - name: Include data which repositories to check

--- a/template/.github/workflows/build.yaml.j2
+++ b/template/.github/workflows/build.yaml.j2
@@ -39,9 +39,11 @@ jobs:
   detect-changes:
     name: Detect relevant changed files
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -67,6 +69,8 @@ jobs:
     if: needs.detect-changes.outputs.detected == 'true'
     needs: [detect-changes]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       RUSTC_BOOTSTRAP: 1
     steps:
@@ -77,7 +81,7 @@ jobs:
           version: ubuntu-latest
 
       - name: Checkout Repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           submodules: recursive
@@ -91,6 +95,7 @@ jobs:
         with:
           cache-all-crates: "true"
           key: udeps
+          lookup-only: ${{ github.event_name == 'pull_request' }}
 
       - name: Install cargo-udeps
         uses: stackabletech/cargo-install-action@8f7dbbcd2ebe22717efc132d0dd61e80841994b9 # cargo-udeps
@@ -103,6 +108,7 @@ jobs:
     if: (github.event_name != 'merge_group') && needs.detect-changes.outputs.detected == 'true'
     needs: [detect-changes]
     permissions:
+      contents: read
       id-token: write
     strategy:
       fail-fast: false
@@ -114,14 +120,25 @@ jobs:
     outputs:
       operator-version: ${{ steps.version.outputs.OPERATOR_VERSION }}
     steps:
+      # Use cached apt packages on PRs.
+      # For merges to main and releases, bypass the cache and install fresh package to ensure we have the absolute latest versions.
       - name: Install host dependencies
+        if: github.event_name == 'pull_request'
         uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # v1.5.3
         with:
           packages: protobuf-compiler krb5-user libkrb5-dev libclang-dev liblzma-dev libssl-dev pkg-config apt-transport-https
           version: ${{ matrix.runner.name }}
 
+      - name: Install host dependencies (no cache)
+        if: github.event_name != 'pull_request'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler krb5-user libkrb5-dev \
+            libclang-dev liblzma-dev libssl-dev pkg-config apt-transport-https
+
+
       - name: Checkout Repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           submodules: recursive
@@ -203,6 +220,7 @@ jobs:
       - detect-changes
       - build-container-image
     permissions:
+      contents: read
       id-token: write
     runs-on: ubuntu-latest
     outputs:
@@ -210,7 +228,7 @@ jobs:
       quay-index-digest: ${{ steps.publish-quay.outputs.image-index-manifest-digest }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -297,15 +315,17 @@ jobs:
     if: |
       (github.event_name != 'merge_group')
       && needs.detect-changes.outputs.detected == 'true'
+      && !github.event.pull_request.head.repo.fork
     needs:
       - detect-changes
       - build-container-image
     permissions:
+      contents: read
       id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           submodules: recursive
@@ -394,13 +414,9 @@ jobs:
       - provenance-oci
       - provenance-quay
       - publish-helm-chart
+      - finished
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          persist-credentials: false
-
       - name: Send Notification
         uses: stackabletech/actions/send-slack-notification@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
         with:

--- a/template/.github/workflows/build.yaml.j2
+++ b/template/.github/workflows/build.yaml.j2
@@ -59,8 +59,9 @@ jobs:
             - 'deploy/**'
             - '.cargo/**'
             - 'docker/**'
-            - 'Cargo.*'
-            - '*.rs'
+            - '**/Cargo.toml'
+            - 'Cargo.lock'
+            - '**/*.rs'
     outputs:
       detected: ${{ steps.check.outputs.detected }}
 
@@ -75,7 +76,7 @@ jobs:
       RUSTC_BOOTSTRAP: 1
     steps:
       - name: Install host dependencies
-        uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # v1.5.3
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: protobuf-compiler krb5-user libkrb5-dev libclang-dev liblzma-dev libssl-dev pkg-config apt-transport-https
           version: ubuntu-latest
@@ -95,17 +96,19 @@ jobs:
         with:
           cache-all-crates: "true"
           key: udeps
-          lookup-only: ${{ github.event_name == 'pull_request' }}
 
       - name: Install cargo-udeps
-        uses: stackabletech/cargo-install-action@8f7dbbcd2ebe22717efc132d0dd61e80841994b9 # cargo-udeps
+        uses: stackabletech/cargo-install-action@e3e2dcf8d0f0e5bdbc619bf6ee7560dd68152d3c # cargo-udeps
 
       - name: Run cargo-udeps
         run: cargo udeps --workspace --all-targets
 
   build-container-image:
     name: Build/Publish ${{ matrix.runner.arch }} Image
-    if: (github.event_name != 'merge_group') && needs.detect-changes.outputs.detected == 'true'
+    if: |
+      github.repository_owner == 'stackabletech'
+      && (github.event_name != 'merge_group')
+      && needs.detect-changes.outputs.detected == 'true'
     needs: [detect-changes]
     permissions:
       contents: read
@@ -120,22 +123,11 @@ jobs:
     outputs:
       operator-version: ${{ steps.version.outputs.OPERATOR_VERSION }}
     steps:
-      # Use cached apt packages on PRs.
-      # For merges to main and releases, bypass the cache and install fresh package to ensure we have the absolute latest versions.
       - name: Install host dependencies
-        if: github.event_name == 'pull_request'
-        uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # v1.5.3
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: protobuf-compiler krb5-user libkrb5-dev libclang-dev liblzma-dev libssl-dev pkg-config apt-transport-https
           version: ${{ matrix.runner.name }}
-
-      - name: Install host dependencies (no cache)
-        if: github.event_name != 'pull_request'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler krb5-user libkrb5-dev \
-            libclang-dev liblzma-dev libssl-dev pkg-config apt-transport-https
-
 
       - name: Checkout Repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -173,7 +165,7 @@ jobs:
           echo "OPERATOR_VERSION=$NEW_VERSION" | tee -a "$GITHUB_OUTPUT"
 
       - name: Install Nix
-        uses: cachix/install-nix-action@fc6e360bedc9ee72d75e701397f0bb30dce77568 # v31.5.2
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
 
       - name: Install Rust ${{ env.RUST_TOOLCHAIN_VERSION }} Toolchain
         shell: bash
@@ -213,7 +205,8 @@ jobs:
   publish-index-manifest:
     name: Publish/Sign ${{ needs.build-container-image.outputs.operator-version }} Index
     if: |
-      (github.event_name != 'merge_group')
+      github.repository_owner == 'stackabletech'
+      && (github.event_name != 'merge_group')
       && needs.detect-changes.outputs.detected == 'true'
       && !github.event.pull_request.head.repo.fork
     needs:
@@ -259,7 +252,8 @@ jobs:
   provenance-oci:
     name: Generate Provenance for ${{ needs.build-container-image.outputs.operator-version }} (oci.stackable.tech)
     if: |
-      (github.event_name != 'merge_group')
+      github.repository_owner == 'stackabletech'
+      && (github.event_name != 'merge_group')
       && needs.detect-changes.outputs.detected == 'true'
       && !github.event.pull_request.head.repo.fork
     needs:
@@ -286,7 +280,8 @@ jobs:
   provenance-quay:
     name: Generate Provenance for ${{ needs.build-container-image.outputs.operator-version }} (quay.io)
     if: |
-      (github.event_name != 'merge_group')
+      github.repository_owner == 'stackabletech'
+      && (github.event_name != 'merge_group')
       && needs.detect-changes.outputs.detected == 'true'
       && !github.event.pull_request.head.repo.fork
     needs:
@@ -313,7 +308,8 @@ jobs:
   publish-helm-chart:
     name: Package/Publish ${{ needs.build-container-image.outputs.operator-version }} Helm Chart
     if: |
-      (github.event_name != 'merge_group')
+      github.repository_owner == 'stackabletech'
+      && (github.event_name != 'merge_group')
       && needs.detect-changes.outputs.detected == 'true'
       && !github.event.pull_request.head.repo.fork
     needs:
@@ -358,7 +354,8 @@ jobs:
   openshift-preflight-check:
     name: Run OpenShift Preflight Check for ${{ needs.build-container-image.outputs.operator-version }}-${{ matrix.arch }}
     if: |
-      (github.event_name != 'merge_group')
+      github.repository_owner == 'stackabletech'
+      && (github.event_name != 'merge_group')
       && needs.detect-changes.outputs.detected == 'true'
       && !github.event.pull_request.head.repo.fork
     needs:
@@ -392,28 +389,45 @@ jobs:
     # WARNING: Do not change the name unless you will also be changing the
     # Required Checks (in branch protections) in GitHub settings.
     name: Finished Build and Publish
+    if: always()
     needs:
+      - detect-changes
       - cargo-udeps
+      - build-container-image
+      - publish-index-manifest
       - openshift-preflight-check
       - publish-helm-chart
+      - provenance-oci
+      - provenance-quay
     runs-on: ubuntu-latest
     steps:
-      - run: echo "We are done here"
+      - name: Fail if a required job failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "One or more required jobs failed or were cancelled."
+          exit 1
+
+      - name: Finished
+        run: echo "All required jobs succeeded or were intentionally skipped."
 
   notify:
     name: Failure Notification
     if: |
-      (failure() || github.run_attempt > 1)
+      !cancelled()
+      && github.repository_owner == 'stackabletech'
+      && (contains(needs.*.result, 'failure') || github.run_attempt > 1)
       && github.event_name != 'merge_group'
       && needs.detect-changes.outputs.detected == 'true'
       && !github.event.pull_request.head.repo.fork
     needs:
       - detect-changes
+      - cargo-udeps
       - build-container-image
       - publish-index-manifest
       - provenance-oci
       - provenance-quay
       - publish-helm-chart
+      - openshift-preflight-check
       - finished
     runs-on: ubuntu-latest
     steps:

--- a/template/.github/workflows/general_daily_security.yml
+++ b/template/.github/workflows/general_daily_security.yml
@@ -15,8 +15,12 @@ permissions: {}
 jobs:
   audit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      issues: write
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0

--- a/template/.github/workflows/general_daily_security.yml
+++ b/template/.github/workflows/general_daily_security.yml
@@ -18,11 +18,15 @@ jobs:
     permissions:
       contents: read
       checks: write
-      issues: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+        # Build against stable because cargo-audit sometimes depends on things
+        # that require a newer Rust version than our pinned toolchain. This does
+        # not influence the result, so it should be safe.
+        env:
+          RUSTUP_TOOLCHAIN: stable
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/template/.github/workflows/general_daily_security.yml
+++ b/template/.github/workflows/general_daily_security.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      #rustsec/audit-check publishes its results as a Check run, which requires this scope
       checks: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/template/.github/workflows/general_daily_security.yml
+++ b/template/.github/workflows/general_daily_security.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      #rustsec/audit-check publishes its results as a Check run, which requires this scope
+      # rustsec/audit-check publishes its results as a Check run, which requires this scope
       checks: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/template/.github/workflows/integration-test.yml
+++ b/template/.github/workflows/integration-test.yml
@@ -16,7 +16,7 @@ on:
           - custom
       test-mode-input:
         description: |
-          The profile or the runner used. Eg: `smoke-latest` or `amd64` (see test/interu.yaml)
+          The profile or the runner used. Eg: `smoke-latest` or `amd64` (see tests/interu.yaml)
         required: true
       test-suite:
         description: Name of the test-suite. Only used if test-mode is `custom`

--- a/template/.github/workflows/integration-test.yml
+++ b/template/.github/workflows/integration-test.yml
@@ -29,13 +29,15 @@ jobs:
   test:
     name: Run Integration Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     # services:
     #   otel-collector:
     #     image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-k8s:0.131.1
     #     volumes:
     #       - .:/mnt
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           submodules: recursive

--- a/template/.github/workflows/pr_prek.yaml.j2
+++ b/template/.github/workflows/pr_prek.yaml.j2
@@ -17,13 +17,15 @@ env:
 jobs:
   prek:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Install host dependencies
         uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: protobuf-compiler krb5-user libkrb5-dev libclang-dev liblzma-dev libssl-dev pkg-config apt-transport-https
           version: ubuntu-latest
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           submodules: recursive

--- a/template/.github/workflows/pr_prek.yaml.j2
+++ b/template/.github/workflows/pr_prek.yaml.j2
@@ -21,7 +21,7 @@ jobs:
       contents: read
     steps:
       - name: Install host dependencies
-        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
+        uses: awalsh128/cache-apt-pkgs-action@553a35bb8ebd9fcabcb1c9451aa4c98e1b4ca8a9 # v1.6.3
         with:
           packages: protobuf-compiler krb5-user libkrb5-dev libclang-dev liblzma-dev libssl-dev pkg-config apt-transport-https
           version: ubuntu-latest

--- a/test.sh
+++ b/test.sh
@@ -2,4 +2,4 @@
 
 rm -fr work || true
 mkdir -p work
-ansible-playbook playbook/playbook.yaml --tags="local" --extra-vars "gh_access_token=unneeded base_dir=$(pwd) commit_hash=12345 reason='original message'" "$@"
+GH_ACCESS_TOKEN=unneeded ansible-playbook playbook/playbook.yaml --tags="local" --extra-vars "base_dir=$(pwd) commit_hash=12345 reason='original message'" "$@"


### PR DESCRIPTION
This PR introduces a collection of 'correctness fixes' and 'hygiene' improvements to the CI templates:

Including: 

- Fix failure condition to check actual job results e.g a skipped job will silently pass
- Add missing job dependencies to notify and validate all required jobs in finished
- Guard build-container-image, publish, provenance, preflight and notify jobs with github.repository_owner == 'stackabletech' so fork PRs no longer queue runners or attempt to push images
- Pinned deps to latest hashes
- Some other small hardening improvements 
