### PR TITLE
fix(template): Use operator name in docs templating script

### DIFF
--- a/template/scripts/docs_templating.sh.j2
+++ b/template/scripts/docs_templating.sh.j2
@@ -39,6 +39,6 @@ do
 done
 
 # Ensure this script is executable
-chmod +x docs/modules/{[ operator.name }]/examples/getting_started/getting_started.sh || chmod +x docs/modules/{[ operator.name }]/examples/getting_started/code/getting_started.sh || true
+chmod +x "docs/modules/{[ operator.name }]/examples/getting_started/getting_started.sh" || chmod +x "docs/modules/{[ operator.name }]/examples/getting_started/code/getting_started.sh" || true
 
 echo "done"

--- a/template/scripts/docs_templating.sh.j2
+++ b/template/scripts/docs_templating.sh.j2
@@ -39,6 +39,8 @@ do
 done
 
 # Ensure this script is executable
-chmod +x "docs/modules/{[ operator.name }]/examples/getting_started/getting_started.sh" || chmod +x "docs/modules/{[ operator.name }]/examples/getting_started/code/getting_started.sh" || true
+chmod +x "docs/modules/{[ operator.name }]/examples/getting_started/getting_started.sh" \
+  || chmod +x "docs/modules/{[ operator.name }]/examples/getting_started/code/getting_started.sh" \
+  || true
 
 echo "done"

--- a/template/scripts/docs_templating.sh.j2
+++ b/template/scripts/docs_templating.sh.j2
@@ -39,6 +39,6 @@ do
 done
 
 # Ensure this script is executable
-chmod +x docs/modules/opensearch/examples/getting_started/getting_started.sh
+chmod +x docs/modules/{[ operator.name }]/examples/getting_started/getting_started.sh || chmod +x docs/modules/{[ operator.name }]/examples/getting_started/code/getting_started.sh || true
 
 echo "done"


### PR DESCRIPTION
Discovered via `./release/create-release-candidate-branch.sh -t 26.7.0-rc1 -w operators -p` during the release of 26.7.0.

This fix needs to be rolled out, merged into `main`, and then cherry-picked into the already cut `release-26.7` branches.