### PR TITLE
fix(template): Use product name in docs templating script

### DIFF
--- a/template/scripts/docs_templating.sh.j2
+++ b/template/scripts/docs_templating.sh.j2
@@ -39,8 +39,8 @@ do
 done
 
 # Ensure this script is executable
-chmod +x "docs/modules/{[ operator.name }]/examples/getting_started/getting_started.sh" \
-  || chmod +x "docs/modules/{[ operator.name }]/examples/getting_started/code/getting_started.sh" \
+chmod +x "docs/modules/{[ operator.product_string }]/examples/getting_started/getting_started.sh" \
+  || chmod +x "docs/modules/{[ operator.product_string }]/examples/getting_started/code/getting_started.sh" \
   || true
 
 echo "done"


### PR DESCRIPTION
This was already done manually in the previous downstream PRs - no need to rollout _right now_.