### PR TITLE
chore: Use consistent product name for commons-operator

### DIFF
--- a/config/repositories.yaml
+++ b/config/repositories.yaml
@@ -9,7 +9,7 @@ repositories:
 
   - name: commons-operator
     pretty_string: Stackable Commons
-    product_string: commons
+    product_string: commons-operator
     url: stackabletech/commons-operator.git
     config:
       include_productconfig: false


### PR DESCRIPTION
This change is done to be in line with our other "internal/core" operators.