### PR TITLE
ci(template): build cargo-audit against stable rust toolchain

### DIFF
--- a/template/.github/workflows/general_daily_security.yml
+++ b/template/.github/workflows/general_daily_security.yml
@@ -20,5 +20,10 @@ jobs:
         with:
           persist-credentials: false
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+        # Build against stable because cargo-audit sometimes depends on things
+        # that require a newer Rust version than our pinned toolchain. This does
+        # not influence the result, so it should be safe.
+        env:
+          RUSTUP_TOOLCHAIN: stable
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

The daily security audit has been [failing](https://github.com/stackabletech/hdfs-operator/actions) for a couple of days because a dependency of `cargo-audit` (`kstring`) now requires Rust 1.96.0 to build. See one example
(`general_daily_security.yml`) 

This PR makes it so that cargo-audit builds against the current stable version instead of our pinned one.
I'm fairly certain this fixes the issue itself but the cost will be a slightly longer runtime because it needs to download the second toolchain I guess. Opinions welcome.

Edit: I just realize that runtime doesn't matter much for the nightly cron job...

@StefanFl @dervoeti Not sure if we even still want/need these runs at all?