### PR TITLE
fix(template): Make "Finished Build and Publish" gate reflect real build outcome

### DIFF
--- a/template/.github/workflows/build.yaml.j2
+++ b/template/.github/workflows/build.yaml.j2
@@ -372,13 +372,41 @@ jobs:
     # WARNING: Do not change the name unless you will also be changing the
     # Required Checks (in branch protections) in GitHub settings.
     name: Finished Build and Publish
+    # Run even when a dependency failed, was skipped or cancelled, so that this
+    # gate reflects the real outcome. Without `always()` a failed dependency
+    # would *skip* this job, and GitHub treats a skipped required check as
+    # passing - making a broken build mergeable.
+    if: always()
+    # List every leaf job directly. A transitive failure (e.g. a failed
+    # publish-index-manifest that skips openshift-preflight-check) does not
+    # surface as `failure` in `needs.*.result` unless the failing job is a
+    # direct dependency.
     needs:
+      - detect-changes
       - cargo-udeps
-      - openshift-preflight-check
+      - build-container-image
+      - publish-index-manifest
+      - provenance-oci
+      - provenance-quay
       - publish-helm-chart
+      - openshift-preflight-check
     runs-on: ubuntu-latest
     steps:
-      - run: echo "We are done here"
+      # Skipped dependencies are fine (jobs skip legitimately on merge_group
+      # events, forks, or when detect-changes finds no relevant changes). Only
+      # a failure or cancellation must fail this gate.
+      - name: Fail on any failed or cancelled dependency
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          echo "Dependency results: $RESULTS"
+          for result in $RESULTS; do
+            if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
+              echo "::error::A required job did not succeed (result: $result)"
+              exit 1
+            fi
+          done
+          echo "We are done here"
 
   notify:
     name: Failure Notification


### PR DESCRIPTION
## Problem

The `finished` job (`Finished Build and Publish`) is the single required status check for the build workflow. We did this so we don't have to list every step in between as required.

During our 26.7 release we saw a build that succeeded even though it shouldn't have: https://github.com/stackabletech/listener-operator/actions/runs/29825092091

## Fix

Github considers _skipped_ jobs as succeeded rather than failing the job. So we need to make sure our `finished` job always runs.

This PR changes it by introducing an `if: always()` to the job

- **`if: always()`** so the gate always runs and reports a real success/failure conclusion.
- **List every leaf job directly in `needs`** and fail on any `failure`/`cancelled` result. `publish-index-manifest` was previously only a *transitive* dependency (via `openshift-preflight-check`), so its failure would not surface in `needs.*.result` even with `always()`.
- `skipped` is tolerated on purpose, jobs skip legitimately on `merge_group` events, forks, and when `detect-changes` finds no relevant changes.