### PR TITLE
chore: retire orphaned issue templates from operator repos

### DIFF
--- a/config/retired_files.yaml
+++ b/config/retired_files.yaml
@@ -6,3 +6,6 @@ retired_files:
   - .readme/static/borrowed/sdp_overview.png
   - .github/workflows/pr_pre-commit.yaml
   - .github/workflows/build.yml
+  - .github/ISSUE_TEMPLATE/normal-issue.md
+  - .github/ISSUE_TEMPLATE/new_version.md
+  - .github/ISSUE_TEMPLATE/bug_report.yml


### PR DESCRIPTION
I was doing a sweep of issue templates and found these in our repos... must be from way back when.