### PR TITLE
fix(template): Use product string in docs templating script

### DIFF
--- a/config/repositories.yaml
+++ b/config/repositories.yaml
@@ -9,7 +9,7 @@ repositories:
 
   - name: commons-operator
     pretty_string: Stackable Commons
-    product_string: commons
+    product_string: commons-operator
     url: stackabletech/commons-operator.git
     config:
       has_product: false

--- a/template/scripts/docs_templating.sh.j2
+++ b/template/scripts/docs_templating.sh.j2
@@ -39,8 +39,8 @@ do
 done
 
 # Ensure this script is executable
-chmod +x "docs/modules/{[ operator.name }]/examples/getting_started/getting_started.sh" \
-  || chmod +x "docs/modules/{[ operator.name }]/examples/getting_started/code/getting_started.sh" \
+chmod +x "docs/modules/{[ operator.product_string }]/examples/getting_started/getting_started.sh" \
+  || chmod +x "docs/modules/{[ operator.product_string }]/examples/getting_started/code/getting_started.sh" \
   || true
 
 echo "done"


### PR DESCRIPTION
This was fixed manually in downstream operators during the work for release 26.7.0. This PR fixes it directly in templating.