### PR TITLE
ci(template): Bump stackabletech/actions to v0.16.3

### DIFF
--- a/.github/workflows/pr_prek.yml
+++ b/.github/workflows/pr_prek.yml
@@ -17,6 +17,6 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-      - uses: stackabletech/actions/run-prek@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
+      - uses: stackabletech/actions/run-prek@dc83bb926cc464f0f32454e934777116bd1c7768 # v0.16.3
         with:
           hadolint: ${{ env.HADOLINT_VERSION }}

--- a/template/.github/workflows/build.yaml.j2
+++ b/template/.github/workflows/build.yaml.j2
@@ -48,7 +48,7 @@ jobs:
 
       - name: Check for changed files
         id: check
-        uses: stackabletech/actions/detect-changes@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
+        uses: stackabletech/actions/detect-changes@dc83bb926cc464f0f32454e934777116bd1c7768 # v0.16.3
         with:
           patterns: |
             - '.github/workflows/build.yaml'
@@ -164,7 +164,7 @@ jobs:
 
       - name: Build Container Image
         id: build
-        uses: stackabletech/actions/build-container-image@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
+        uses: stackabletech/actions/build-container-image@dc83bb926cc464f0f32454e934777116bd1c7768 # v0.16.3
         with:
           image-name: ${{ env.OPERATOR_NAME }}
           image-index-manifest-tag: ${{ steps.version.outputs.OPERATOR_VERSION }}
@@ -173,7 +173,7 @@ jobs:
 
       - name: Publish Container Image to oci.stackable.tech
         if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: stackabletech/actions/publish-image@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
+        uses: stackabletech/actions/publish-image@dc83bb926cc464f0f32454e934777116bd1c7768 # v0.16.3
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -184,7 +184,7 @@ jobs:
 
       - name: Publish Container Image to quay.io
         if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: stackabletech/actions/publish-image@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
+        uses: stackabletech/actions/publish-image@dc83bb926cc464f0f32454e934777116bd1c7768 # v0.16.3
         with:
           image-registry-uri: quay.io
           image-registry-username: stackable+robot_sdp_github_action_build
@@ -216,7 +216,7 @@ jobs:
 
       - name: Publish and Sign Image Index to oci.stackable.tech
         id: publish-oci
-        uses: stackabletech/actions/publish-image-index-manifest@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
+        uses: stackabletech/actions/publish-image-index-manifest@dc83bb926cc464f0f32454e934777116bd1c7768 # v0.16.3
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -226,7 +226,7 @@ jobs:
 
       - name: Publish and Sign Image Index to quay.io
         id: publish-quay
-        uses: stackabletech/actions/publish-image-index-manifest@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
+        uses: stackabletech/actions/publish-image-index-manifest@dc83bb926cc464f0f32454e934777116bd1c7768 # v0.16.3
         with:
           image-registry-uri: quay.io
           image-registry-username: stackable+robot_sdp_github_action_build
@@ -311,7 +311,7 @@ jobs:
           submodules: recursive
 
       - name: Package, Publish, and Sign Helm Chart to oci.stackable.tech
-        uses: stackabletech/actions/publish-helm-chart@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
+        uses: stackabletech/actions/publish-helm-chart@dc83bb926cc464f0f32454e934777116bd1c7768 # v0.16.3
         with:
           chart-registry-uri: oci.stackable.tech
           chart-registry-username: robot$sdp-charts+github-action-build
@@ -323,7 +323,7 @@ jobs:
           publish-and-sign: ${{ !github.event.pull_request.head.repo.fork }}
 
       - name: Package, Publish, and Sign Helm Chart to quay.io
-        uses: stackabletech/actions/publish-helm-chart@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
+        uses: stackabletech/actions/publish-helm-chart@dc83bb926cc464f0f32454e934777116bd1c7768 # v0.16.3
         with:
           chart-registry-uri: quay.io
           chart-registry-username: stackable+robot_sdp_charts_github_action_build
@@ -354,13 +354,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run OpenShift Preflight Check for oci.stackable.tech
-        uses: stackabletech/actions/run-openshift-preflight@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
+        uses: stackabletech/actions/run-openshift-preflight@dc83bb926cc464f0f32454e934777116bd1c7768 # v0.16.3
         with:
           image-index-uri: oci.stackable.tech/sdp/${{ env.OPERATOR_NAME }}:${{ needs.build-container-image.outputs.operator-version }}
           image-architecture: ${{ matrix.arch }}
 
       - name: Run OpenShift Preflight Check for quay.io
-        uses: stackabletech/actions/run-openshift-preflight@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
+        uses: stackabletech/actions/run-openshift-preflight@dc83bb926cc464f0f32454e934777116bd1c7768 # v0.16.3
         with:
           image-index-uri: quay.io/stackable/sdp/${{ env.OPERATOR_NAME }}:${{ needs.build-container-image.outputs.operator-version }}
           image-architecture: ${{ matrix.arch }}
@@ -402,11 +402,20 @@ jobs:
           persist-credentials: false
 
       - name: Send Notification
-        uses: stackabletech/actions/send-slack-notification@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
+        uses: stackabletech/actions/send-slack-notification@dc83bb926cc464f0f32454e934777116bd1c7768 # v0.16.3
         with:
           publish-helm-chart-result: ${{ needs.publish-helm-chart.result }}
           publish-manifests-result: ${{ needs.publish-index-manifest.result }}
           build-result: ${{ needs.build-container-image.result }}
+          # Provenance is generated per registry, but the notification only has a
+          # single field for it, so the two results are collapsed into the worst
+          # one. 'failure' must be reported verbatim, otherwise the notification
+          # is not marked as failed.
+          generate-provenance-result: >-
+            ${{ (needs.provenance-oci.result == 'failure' || needs.provenance-quay.result == 'failure') && 'failure'
+            || (needs.provenance-oci.result == 'cancelled' || needs.provenance-quay.result == 'cancelled') && 'cancelled'
+            || (needs.provenance-oci.result == 'skipped' || needs.provenance-quay.result == 'skipped') && 'skipped'
+            || 'success' }}
           slack-token: ${{ secrets.SLACK_CONTAINER_IMAGE_TOKEN }}
           channel-id: C07UG6JH44F # notifications-container-images
           type: container-image-build

--- a/template/.github/workflows/integration-test.yml
+++ b/template/.github/workflows/integration-test.yml
@@ -43,7 +43,7 @@ jobs:
       # TODO: Enable the scheduled runs which hard-code what profile to use
       - name: Run Integration Test
         id: test
-        uses: stackabletech/actions/run-integration-test@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
+        uses: stackabletech/actions/run-integration-test@dc83bb926cc464f0f32454e934777116bd1c7768 # v0.16.3
         with:
           replicated-api-token: ${{ secrets.REPLICATED_API_TOKEN }}
           test-mode-input: ${{ inputs.test-mode-input }}
@@ -53,7 +53,7 @@ jobs:
 
       - name: Send Notification
         if: ${{ failure() || github.run_attempt > 1 }}
-        uses: stackabletech/actions/send-slack-notification@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
+        uses: stackabletech/actions/send-slack-notification@dc83bb926cc464f0f32454e934777116bd1c7768 # v0.16.3
         with:
           slack-token: ${{ secrets.SLACK_INTEGRATION_TEST_TOKEN }}
           failed-tests: ${{ steps.test.outputs.failed-tests }}

--- a/template/.github/workflows/pr_prek.yaml.j2
+++ b/template/.github/workflows/pr_prek.yaml.j2
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
           submodules: recursive
           fetch-depth: 0
-      - uses: stackabletech/actions/run-prek@a8af17a19bdcc3b5da0065f76e73827ba0c072ce # v0.16.0
+      - uses: stackabletech/actions/run-prek@dc83bb926cc464f0f32454e934777116bd1c7768 # v0.16.3
         with:
           rust: ${{ env.RUST_TOOLCHAIN_VERSION }}
           hadolint: ${{ env.HADOLINT_VERSION }}


### PR DESCRIPTION
# Description

Bumps `stackabletech/actions` from v0.16.0 to v0.16.3.

Included upstream changes are SBOM improvements (shrinked the size, already rolled out in docker-images) and the fix for the provenance job (a failing provenance job did not mark the container image build notification as failed).