### PR TITLE
fix: Set correct user IDs for container images build by nix

### DIFF
--- a/template/default.nix
+++ b/template/default.nix
@@ -133,6 +133,12 @@ rec {
     ${entrypoint} crd > $out
   '';
 
+  # The unprivileged user that the operator runs as.
+  # These values must be kept in sync with docker/Dockerfile!
+  stackableUserName = "stackable";
+  stackableUserUid = 782252253;
+  stackableUserGid = 574654813;
+
   # We're building the docker image *for* Linux, but we need to
   # build it in the local environment so that the generated load-image
   # can run locally.
@@ -150,9 +156,37 @@ rec {
       pkgsTarget.coreutils
       pkgsTarget.util-linuxMinimal
     ];
+
+    # Nix images don't contain a user database, so create a minimal one containing the same user
+    # that docker/Dockerfile creates via groupadd/useradd. Without it the UID cannot be resolved to
+    # a name and a home directory, which breaks tools such as `whoami` and makes for a confusing
+    # shell prompt when using `kubectl exec`.
+    extraCommands = ''
+      mkdir -p etc stackable
+      cat > etc/passwd <<EOF
+      root:x:0:0:root:/root:/bin/bash
+      ${stackableUserName}:x:${toString stackableUserUid}:${toString stackableUserGid}:${stackableUserName}:/stackable:/bin/bash
+      EOF
+      cat > etc/group <<EOF
+      root:x:0:
+      ${stackableUserName}:x:${toString stackableUserGid}:
+      EOF
+    '';
+    # All files and folders are owned by the root group to support running as arbitrary users.
+    # This is best practice as all container users will belong to the root group (0).
+    # Same as in docker/Dockerfile.
+    fakeRootCommands = ''
+      chown -R ${toString stackableUserUid}:0 stackable
+      chmod -R g=u stackable
+    '';
+
     config = {
       Entrypoint = [ entrypoint ];
       Cmd = [ "run" ];
+      # Mirrors the `USER` instruction in docker/Dockerfile. Besides not running as root, this is
+      # also required for Pods that set `runAsNonRoot: true` without an explicit `runAsUser`,
+      # because the kubelet refuses to start containers whose image would run as root.
+      User = toString stackableUserUid;
     };
   };
   docker = pkgsLocal.linkFarm "${dockerImage.name}-docker" [

--- a/template/docker/Dockerfile.j2
+++ b/template/docker/Dockerfile.j2
@@ -26,6 +26,7 @@ ARG VERSION
 ARG RELEASE="1"
 
 # These are chosen at random and are this high on purpose to have very little chance to clash with an existing user or group on the host system
+# NOTE: Please also update default.nix accordingly!
 ARG STACKABLE_USER_GID="574654813"
 ARG STACKABLE_USER_UID="782252253"
 ARG STACKABLE_USER_NAME="stackable"


### PR DESCRIPTION
Part of https://github.com/stackabletech/issues/issues/645

I noticed this while working on https://github.com/stackabletech/operator-rs/pull/1205, as the bundle-builder was rejected by Kubernetes up as it wanted to run as root.

I though of templating the IDs, but putting it in config/retired_files.yaml also felt wrong