### PR TITLE
feat: Add Artifact Hub metadata to operator Helm charts (and fix a bit of what was there already)

### DIFF
--- a/config/repositories.yaml
+++ b/config/repositories.yaml
@@ -1,16 +1,39 @@
 # If you add a new repository here, you also need to add it to the list of
 # repositories in ../.github/workflows/generate_prs.yml.
+#
+# chart_description and keywords end up in the Helm chart's Chart.yaml and are
+# indexed by Artifact Hub and our own Hub. Descriptions deliberately use the form "operator for
+# Apache X" rather than "Apache X operator": the ASF mark must refer to the
+# upstream project, not read as part of our product name.
+#
+# hub_component_slug only needs setting where the Hub component slug differs
+# from product_string. Operators with has_product: false have no Hub component
+# at all, so they get no hub_component_slug.
 ---
 repositories:
   - name: airflow-operator
     pretty_string: Apache Airflow
     product_string: airflow
     url: stackabletech/airflow-operator.git
+    chart_description: Kubernetes operator for Apache Airflow. Deploy and run Airflow with the Stackable Data Platform (SDP).
+    keywords:
+      - apache-airflow
+      - airflow
+      - workflow-orchestration
+      - kubernetes
+      - operator
+      - big-data
 
   - name: commons-operator
     pretty_string: Stackable Commons
     product_string: commons-operator
     url: stackabletech/commons-operator.git
+    chart_description: Kubernetes operator for common resources shared across the Stackable Data Platform (SDP).
+    keywords:
+      - stackable
+      - data-platform
+      - kubernetes
+      - operator
     config:
       has_product: false
 
@@ -18,36 +41,97 @@ repositories:
     pretty_string: Apache Druid
     product_string: druid
     url: stackabletech/druid-operator.git
+    chart_description: Kubernetes operator for Apache Druid. Deploy and run Druid clusters with the Stackable Data Platform (SDP).
+    keywords:
+      - apache-druid
+      - druid
+      - olap
+      - analytics
+      - kubernetes
+      - operator
+      - big-data
 
   - name: hbase-operator
     pretty_string: Apache HBase
     product_string: hbase
     url: stackabletech/hbase-operator.git
+    chart_description: Kubernetes operator for Apache HBase. Deploy and run HBase masters and region servers with the Stackable Data Platform (SDP).
+    keywords:
+      - apache-hbase
+      - hbase
+      - nosql
+      - kubernetes
+      - operator
+      - big-data
 
   - name: hdfs-operator
     pretty_string: Apache HDFS
     product_string: hdfs
     url: stackabletech/hdfs-operator.git
+    chart_description: Kubernetes operator for Apache Hadoop HDFS. Deploy and run HDFS NameNodes, DataNodes and JournalNodes with the Stackable Data Platform (SDP).
+    keywords:
+      - apache-hadoop
+      - hadoop
+      - hdfs
+      - storage
+      - kubernetes
+      - operator
+      - big-data
 
   - name: hive-operator
     pretty_string: Apache Hive
     product_string: hive
     url: stackabletech/hive-operator.git
+    chart_description: Kubernetes operator for Apache Hive. Deploy and run the Hive Metastore with the Stackable Data Platform (SDP).
+    keywords:
+      - apache-hive
+      - hive
+      - hive-metastore
+      - metastore
+      - kubernetes
+      - operator
+      - big-data
 
   - name: kafka-operator
     pretty_string: Apache Kafka
     product_string: kafka
     url: stackabletech/kafka-operator.git
+    chart_description: Kubernetes operator for Apache Kafka. Deploy and run Kafka brokers with the Stackable Data Platform (SDP).
+    keywords:
+      - apache-kafka
+      - kafka
+      - streaming
+      - messaging
+      - kubernetes
+      - operator
+      - big-data
 
   - name: nifi-operator
     pretty_string: Apache NiFi
     product_string: nifi
     url: stackabletech/nifi-operator.git
+    chart_description: Kubernetes operator for Apache NiFi. Deploy and run NiFi clusters with the Stackable Data Platform (SDP).
+    keywords:
+      - apache-nifi
+      - nifi
+      - dataflow
+      - etl
+      - kubernetes
+      - operator
+      - big-data
 
   - name: listener-operator
     pretty_string: Stackable Listener Operator
     product_string: listener-operator
     url: stackabletech/listener-operator.git
+    chart_description: Kubernetes operator for exposing pods through listeners, load balancers and NodePorts. Part of the Stackable Data Platform (SDP).
+    keywords:
+      - listener
+      - load-balancer
+      - service-discovery
+      - networking
+      - kubernetes
+      - operator
     config:
       has_product: false
       run_as: custom
@@ -56,6 +140,15 @@ repositories:
     pretty_string: OpenPolicyAgent
     product_string: opa
     url: stackabletech/opa-operator.git
+    chart_description: Kubernetes operator for the Open Policy Agent (OPA). Deploy and run OPA for authorization with the Stackable Data Platform (SDP).
+    keywords:
+      - open-policy-agent
+      - opa
+      - authorization
+      - policy
+      - rego
+      - kubernetes
+      - operator
     config:
       extra_crates:
         - stackable-opa-bundle-builder
@@ -64,11 +157,26 @@ repositories:
     pretty_string: OpenSearch
     product_string: opensearch
     url: stackabletech/opensearch-operator.git
+    chart_description: Kubernetes operator for OpenSearch. Deploy and run OpenSearch clusters with the Stackable Data Platform (SDP).
+    keywords:
+      - opensearch
+      - search
+      - observability
+      - kubernetes
+      - operator
 
   - name: secret-operator
     pretty_string: Stackable Secret Operator
     product_string: secret-operator
     url: stackabletech/secret-operator.git
+    chart_description: Kubernetes operator for provisioning TLS certificates, Kerberos keytabs and other secrets to pods. Part of the Stackable Data Platform (SDP).
+    keywords:
+      - secrets
+      - tls
+      - kerberos
+      - csi
+      - kubernetes
+      - operator
     config:
       has_product: false
       run_as: custom
@@ -76,19 +184,53 @@ repositories:
   - name: spark-k8s-operator
     pretty_string: Apache Spark-on-Kubernetes
     product_string: spark-k8s
+    hub_component_slug: spark
     url: stackabletech/spark-k8s-operator.git
+    chart_description: Kubernetes operator for Apache Spark. Run Spark applications on Kubernetes with the Stackable Data Platform (SDP).
+    keywords:
+      - apache-spark
+      - spark
+      - spark-on-kubernetes
+      - kubernetes
+      - operator
+      - big-data
 
   - name: superset-operator
     pretty_string: Apache Superset
     product_string: superset
     url: stackabletech/superset-operator.git
+    chart_description: Kubernetes operator for Apache Superset. Deploy and run Superset with the Stackable Data Platform (SDP).
+    keywords:
+      - apache-superset
+      - superset
+      - business-intelligence
+      - dashboards
+      - kubernetes
+      - operator
 
   - name: trino-operator
     pretty_string: Trino
     product_string: trino
     url: stackabletech/trino-operator.git
+    chart_description: Kubernetes operator for Trino. Deploy and run Trino coordinators and workers with the Stackable Data Platform (SDP).
+    keywords:
+      - trino
+      - sql
+      - query-engine
+      - federation
+      - kubernetes
+      - operator
+      - big-data
 
   - name: zookeeper-operator
     pretty_string: Apache ZooKeeper
     product_string: zookeeper
     url: stackabletech/zookeeper-operator.git
+    chart_description: Kubernetes operator for Apache ZooKeeper. Deploy and run ZooKeeper ensembles with the Stackable Data Platform (SDP).
+    keywords:
+      - apache-zookeeper
+      - zookeeper
+      - coordination
+      - kubernetes
+      - operator
+      - big-data

--- a/template/deploy/helm/[[operator]]/Chart.yaml.j2
+++ b/template/deploy/helm/[[operator]]/Chart.yaml.j2
@@ -3,10 +3,28 @@ apiVersion: v2
 name: {[ operator.name }]
 version: "<version_placeholder>"
 appVersion: "<version_placeholder>"
-description: The Stackable Operator for {[ operator.pretty_string }]
+description: "{[ operator.chart_description }]"
 
 home: https://github.com/stackabletech/{[ operator.name }]
+sources:
+  - https://github.com/stackabletech/{[ operator.name }]
+
+keywords:
+{[%- for keyword in operator.keywords %}]
+  - {[ keyword }]
+{[%- endfor %}]
 
 maintainers:
   - name: Stackable
     url: https://www.stackable.tech
+
+# Consumed by Artifact Hub, see https://artifacthub.io/docs/topics/annotations/helm/
+annotations:
+  # The chart package ships no LICENSE file, so Artifact Hub cannot detect this itself.
+  artifacthub.io/license: OSL-3.0
+  # A link named "support" is rendered highlighted by Artifact Hub. Keep it lowercase.
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://docs.stackable.tech/home/stable/{[ operator.product_string }]/
+    - name: support
+      url: https://github.com/stackabletech/{[ operator.name }]/issues

--- a/template/deploy/helm/[[operator]]/README.md.j2
+++ b/template/deploy/helm/[[operator]]/README.md.j2
@@ -1,28 +1,57 @@
 <!-- markdownlint-disable MD034 -->
+{# markdownlint runs against this template, not the rendered file. A markdown link
+   destination cannot contain spaces, and the Jinja expressions in the URLs below do,
+   so those links do not parse and their URLs get reported as bare. Keep MD034 off.
+
+   The blank line below satisfies MD022 for this template and is stripped from the
+   rendered file by the whitespace-control marker closing this comment. -#}
+
 # Helm Chart for Stackable Operator for {[ operator.pretty_string }]
 
-This Helm Chart can be used to install Custom Resource Definitions and the Operator for {[ operator.pretty_string }] provided by Stackable.
+{[ operator.chart_description }]
 
 ## Requirements
 
-- Create a [Kubernetes Cluster](../Readme.md)
-- Install [Helm](https://helm.sh/docs/intro/install/)
+- A running Kubernetes cluster
+- [Helm](https://helm.sh/docs/intro/install/) 3.8 or newer, for OCI support
 
-## Install the Stackable Operator for {[ operator.pretty_string }]
+## Install
 
 ```bash
-# From the root of the operator repository
-make compile-chart
-
-helm install {[ operator.name }] deploy/helm/{[ operator.name }]
+helm install {[ operator.name }] oci://oci.stackable.tech/sdp-charts/{[ operator.name }]
 ```
 
-## Usage of the CRDs
+Add `--version` to pin a release, for example `--version 26.7.0`.
+Released versions are listed in the [SDP release notes](https://docs.stackable.tech/home/stable/release-notes/) and on the [Stackable Hub](https://hub.stackable.tech/releases).
 
-The usage of this operator and its CRDs is described in the [documentation](https://docs.stackable.tech/{[ operator.product_string }]/index.html)
+Since SDP 26.7 the chart is published to two registries:
 
-The operator has example requests included in the [`/examples`](https://github.com/stackabletech/{[ operator.name }]/tree/main/examples) directory.
+- `oci://oci.stackable.tech/sdp-charts/{[ operator.name }]`
+- `oci://quay.io/stackable/sdp-charts/{[ operator.name }]`
+
+Both hold the same chart, but the registry you install from also decides where the operator pulls product images from.
+Install from quay.io and the operator is configured to use product images from quay.io as well.
+
+Operators are not usually installed on their own.
+Most of them need the commons, secret and listener operators alongside them, and `stackablectl` installs a matching set in one step.
+See the [documentation](https://docs.stackable.tech/home/stable/{[ operator.product_string }]/) for the full picture.
+
+## Custom resources
+
+This operator installs and manages its own CustomResourceDefinitions, so they are not part of this chart.
+The resources it reconciles, and the configuration they accept, are described in the [documentation](https://docs.stackable.tech/home/stable/{[ operator.product_string }]/).
+{[%- if operator.config.has_product | default(true) %}]
+Each CRD is also browsable on the [Stackable Hub](https://hub.stackable.tech/components/{[ operator.hub_component_slug | default(operator.product_string) }]), with its schema and the API versions served per SDP release.
+{[%- endif %}]
 
 ## Links
 
-<https://github.com/stackabletech/{[ operator.name }]>
+- [Documentation](https://docs.stackable.tech/home/stable/{[ operator.product_string }]/)
+- [Stackable Hub](https://hub.stackable.tech/)
+- [Source](https://github.com/stackabletech/{[ operator.name }])
+- [Report an issue](https://github.com/stackabletech/{[ operator.name }]/issues)
+- [Stackable Data Platform](https://stackable.tech/)
+
+## License
+
+[Open Software License version 3.0](https://github.com/stackabletech/{[ operator.name }]/blob/main/LICENSE)


### PR DESCRIPTION
This is part of my work on getting our Charts to appear on ArtifactHub.io but it'll also be helpful when we indext them on the Hub later.

The keywords and descriptions are derived from the ones we use in Github and then mapped to the list of artifacthub.

Also updates the README which was out-of-date (CRDs now managed by operators, quay.io, ...)