### PR TITLE
feat: Add artifacthub-repo.yml for verified publisher and version filtering

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -5,6 +5,7 @@ ignore:
   # yamllint can't parse these files as yaml because of j2 templating
   - template/.github/ISSUE_TEMPLATE/bug_report.yml.j2
   - template/deploy/helm/\[\[operator\]\]/Chart.yaml.j2
+  - template/deploy/helm/artifacthub-repo.yml.j2
   - template/deploy/helm/**/templates
 
 rules:

--- a/config/repositories.yaml
+++ b/config/repositories.yaml
@@ -15,6 +15,7 @@ repositories:
     pretty_string: Apache Airflow
     product_string: airflow
     url: stackabletech/airflow-operator.git
+    artifacthub_repository_id: 81701bbe-789b-4398-846d-cdf4e922d3b2
     chart_description: Kubernetes operator for Apache Airflow. Deploy and run Airflow with the Stackable Data Platform (SDP).
     keywords:
       - apache-airflow
@@ -28,6 +29,7 @@ repositories:
     pretty_string: Stackable Commons
     product_string: commons-operator
     url: stackabletech/commons-operator.git
+    artifacthub_repository_id: 1a53cf2b-a870-4b19-b3cc-e914d02c2076
     chart_description: Kubernetes operator for common resources shared across the Stackable Data Platform (SDP).
     keywords:
       - stackable
@@ -41,6 +43,10 @@ repositories:
     pretty_string: Apache Druid
     product_string: druid
     url: stackabletech/druid-operator.git
+    # Druid is being deprecated and removed from SDP, so it has no
+    # Artifact Hub repository and no metadata file.
+    ignored_files:
+      - deploy/helm/artifacthub-repo.yml.j2
     chart_description: Kubernetes operator for Apache Druid. Deploy and run Druid clusters with the Stackable Data Platform (SDP).
     keywords:
       - apache-druid
@@ -55,6 +61,7 @@ repositories:
     pretty_string: Apache HBase
     product_string: hbase
     url: stackabletech/hbase-operator.git
+    artifacthub_repository_id: 64f82a91-c7c7-4964-8115-c846436f139f
     chart_description: Kubernetes operator for Apache HBase. Deploy and run HBase masters and region servers with the Stackable Data Platform (SDP).
     keywords:
       - apache-hbase
@@ -68,6 +75,7 @@ repositories:
     pretty_string: Apache HDFS
     product_string: hdfs
     url: stackabletech/hdfs-operator.git
+    artifacthub_repository_id: 2d19d362-65c5-47ab-b04a-217b5bd32f2c
     chart_description: Kubernetes operator for Apache Hadoop HDFS. Deploy and run HDFS NameNodes, DataNodes and JournalNodes with the Stackable Data Platform (SDP).
     keywords:
       - apache-hadoop
@@ -82,6 +90,7 @@ repositories:
     pretty_string: Apache Hive
     product_string: hive
     url: stackabletech/hive-operator.git
+    artifacthub_repository_id: 3dcde43a-1a00-44ba-a70c-837d37737140
     chart_description: Kubernetes operator for Apache Hive. Deploy and run the Hive Metastore with the Stackable Data Platform (SDP).
     keywords:
       - apache-hive
@@ -96,6 +105,7 @@ repositories:
     pretty_string: Apache Kafka
     product_string: kafka
     url: stackabletech/kafka-operator.git
+    artifacthub_repository_id: 93d87788-9ae7-4f2f-870d-04134948785a
     chart_description: Kubernetes operator for Apache Kafka. Deploy and run Kafka brokers with the Stackable Data Platform (SDP).
     keywords:
       - apache-kafka
@@ -110,6 +120,7 @@ repositories:
     pretty_string: Apache NiFi
     product_string: nifi
     url: stackabletech/nifi-operator.git
+    artifacthub_repository_id: e0f40fc2-895b-4bbf-9446-91a47035d858
     chart_description: Kubernetes operator for Apache NiFi. Deploy and run NiFi clusters with the Stackable Data Platform (SDP).
     keywords:
       - apache-nifi
@@ -124,6 +135,7 @@ repositories:
     pretty_string: Stackable Listener Operator
     product_string: listener-operator
     url: stackabletech/listener-operator.git
+    artifacthub_repository_id: 739bf044-22df-4d16-b4a9-d2a326e3c821
     chart_description: Kubernetes operator for exposing pods through listeners, load balancers and NodePorts. Part of the Stackable Data Platform (SDP).
     keywords:
       - listener
@@ -140,6 +152,7 @@ repositories:
     pretty_string: OpenPolicyAgent
     product_string: opa
     url: stackabletech/opa-operator.git
+    artifacthub_repository_id: af99c9ca-d938-4416-a154-bc358595b378
     chart_description: Kubernetes operator for the Open Policy Agent (OPA). Deploy and run OPA for authorization with the Stackable Data Platform (SDP).
     keywords:
       - open-policy-agent
@@ -157,6 +170,7 @@ repositories:
     pretty_string: OpenSearch
     product_string: opensearch
     url: stackabletech/opensearch-operator.git
+    artifacthub_repository_id: 379132ea-3510-4899-bb2d-310a415fa419
     chart_description: Kubernetes operator for OpenSearch. Deploy and run OpenSearch clusters with the Stackable Data Platform (SDP).
     keywords:
       - opensearch
@@ -169,6 +183,7 @@ repositories:
     pretty_string: Stackable Secret Operator
     product_string: secret-operator
     url: stackabletech/secret-operator.git
+    artifacthub_repository_id: 8b2d881e-50e2-4810-a01c-338bbfaac78c
     chart_description: Kubernetes operator for provisioning TLS certificates, Kerberos keytabs and other secrets to pods. Part of the Stackable Data Platform (SDP).
     keywords:
       - secrets
@@ -186,6 +201,7 @@ repositories:
     product_string: spark-k8s
     hub_component_slug: spark
     url: stackabletech/spark-k8s-operator.git
+    artifacthub_repository_id: f2de1657-1ef4-483f-905a-c981e38cfb57
     chart_description: Kubernetes operator for Apache Spark. Run Spark applications on Kubernetes with the Stackable Data Platform (SDP).
     keywords:
       - apache-spark
@@ -199,6 +215,7 @@ repositories:
     pretty_string: Apache Superset
     product_string: superset
     url: stackabletech/superset-operator.git
+    artifacthub_repository_id: 49f70221-f2d0-463c-89d8-41682d5d53df
     chart_description: Kubernetes operator for Apache Superset. Deploy and run Superset with the Stackable Data Platform (SDP).
     keywords:
       - apache-superset
@@ -212,6 +229,7 @@ repositories:
     pretty_string: Trino
     product_string: trino
     url: stackabletech/trino-operator.git
+    artifacthub_repository_id: 02de1bee-270f-4d85-bc30-6e5d2288b2b7
     chart_description: Kubernetes operator for Trino. Deploy and run Trino coordinators and workers with the Stackable Data Platform (SDP).
     keywords:
       - trino
@@ -226,6 +244,7 @@ repositories:
     pretty_string: Apache ZooKeeper
     product_string: zookeeper
     url: stackabletech/zookeeper-operator.git
+    artifacthub_repository_id: 60d8c6a9-e317-4d69-868b-b10663af6290
     chart_description: Kubernetes operator for Apache ZooKeeper. Deploy and run ZooKeeper ensembles with the Stackable Data Platform (SDP).
     keywords:
       - apache-zookeeper

--- a/template/deploy/helm/artifacthub-repo.yml.j2
+++ b/template/deploy/helm/artifacthub-repo.yml.j2
@@ -1,0 +1,25 @@
+---
+# Artifact Hub (AH) repository metadata.
+#
+# This is NOT part of the chart.
+# Artifact Hub reads it from a separate OCI artifact pushed to the chart repository under the special `artifacthub.io` tag:
+#
+#   oras push oci.stackable.tech/sdp-charts/{[ operator.name }]:artifacthub.io \
+#     --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
+#     artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
+#
+# Reference: https://github.com/artifacthub/hub/blob/master/docs/metadata/artifacthub-repo.yml and https://artifacthub.io/docs/topics/repositories/#verified-publisher
+
+# Enables the "Verified publisher" label in AH. Taken from the repository's card in
+# the Artifact Hub control panel. Not a secret.
+#
+# Every operator that gets this file has an ID. An operator without an Artifact Hub
+# repository excludes the file entirely via `ignored_files` in
+# config/repositories.yaml, the way druid does while it is being removed from SDP.
+repositoryID: {[ operator.artifacthub_repository_id }]
+
+# Versions Artifact Hub should not index.
+# This excludes all dev/rc/pr charts.
+ignore:
+  - name: {[ operator.name }]
+    version: '-(dev|rc|pr)'


### PR DESCRIPTION
Artifact Hub reads this file from a special `artifacthub.io` tag on the chart's OCI repository, not from the chart itself. repositoryID enables the Verified publisher label.
And using the "ignore" thing we can keep dev, rc and PR tags out of AH.