### PR TITLE
feat: Add a chart icon for Artifact Hub

### DIFF
--- a/template/deploy/helm/[[operator]]/Chart.yaml.j2
+++ b/template/deploy/helm/[[operator]]/Chart.yaml.j2
@@ -6,6 +6,10 @@ appVersion: "<version_placeholder>"
 description: "{[ operator.chart_description }]"
 
 home: https://github.com/stackabletech/{[ operator.name }]
+# One known use of this is the Artifact Hub (AH) listing which shows the logo.
+# AH downloads the logo and re-hosts it.
+# We opted to not use the project logos (e.g. the Apache Spark logo) here due to trademark concerns.
+icon: https://raw.githubusercontent.com/stackabletech/{[ operator.name }]/main/.readme/static/borrowed/Icon_Stackable.svg
 sources:
   - https://github.com/stackabletech/{[ operator.name }]
 


### PR DESCRIPTION
Yes, I have a _slight_ concern about the stability of that URL. But a) I don't think we have a better stable URL right now b) it should only be read once at index time anyway and c) if there is ever a problem this is not a big deal to show the default logo again.