### PR TITLE
fix: Stop doubling "Operator" in the chart README heading

### DIFF
--- a/config/repositories.yaml
+++ b/config/repositories.yaml
@@ -26,6 +26,7 @@ repositories:
 
   - name: commons-operator
     pretty_string: Stackable Commons
+    chart_title: Stackable Commons Operator
     product_string: commons-operator
     url: stackabletech/commons-operator.git
     chart_description: Kubernetes operator for common resources shared across the Stackable Data Platform (SDP).
@@ -122,6 +123,7 @@ repositories:
 
   - name: listener-operator
     pretty_string: Stackable Listener Operator
+    chart_title: Stackable Listener Operator
     product_string: listener-operator
     url: stackabletech/listener-operator.git
     chart_description: Kubernetes operator for exposing pods through listeners, load balancers and NodePorts. Part of the Stackable Data Platform (SDP).
@@ -167,6 +169,7 @@ repositories:
 
   - name: secret-operator
     pretty_string: Stackable Secret Operator
+    chart_title: Stackable Secret Operator
     product_string: secret-operator
     url: stackabletech/secret-operator.git
     chart_description: Kubernetes operator for provisioning TLS certificates, Kerberos keytabs and other secrets to pods. Part of the Stackable Data Platform (SDP).

--- a/template/deploy/helm/[[operator]]/README.md.j2
+++ b/template/deploy/helm/[[operator]]/README.md.j2
@@ -6,7 +6,7 @@
    The blank line below satisfies MD022 for this template and is stripped from the
    rendered file by the whitespace-control marker closing this comment. -#}
 
-# Helm Chart for Stackable Operator for {[ operator.pretty_string }]
+# Helm Chart for {[ operator.chart_title | default("Stackable Operator for " + operator.pretty_string) }]
 
 {[ operator.chart_description }]
 


### PR DESCRIPTION
listener operator would show as "Helm Chart for Stackable Operator for Stackable Listener Operator" which obviously is ...meeh.

This introduces an optional "chart_title" variable which can be used to override the generated title.