### PR TITLE
ci: Bump stackabletech/actions to v0.17.5

### DIFF
--- a/.github/workflows/pr_prek.yml
+++ b/.github/workflows/pr_prek.yml
@@ -19,6 +19,6 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-      - uses: stackabletech/actions/run-prek@bc17d3c4808a2343685853d0d757ad7614f660d4 # v0.17.4
+      - uses: stackabletech/actions/run-prek@0fe048f952bee522474903a925ea48dc706a0bb4 # v0.17.5
         with:
           hadolint: ${{ env.HADOLINT_VERSION }}

--- a/template/.github/workflows/build.yaml.j2
+++ b/template/.github/workflows/build.yaml.j2
@@ -50,7 +50,7 @@ jobs:
 
       - name: Check for changed files
         id: check
-        uses: stackabletech/actions/detect-changes@bc17d3c4808a2343685853d0d757ad7614f660d4 # v0.17.4
+        uses: stackabletech/actions/detect-changes@0fe048f952bee522474903a925ea48dc706a0bb4 # v0.17.5
         with:
           patterns: |
             - '.github/workflows/build.yaml'
@@ -175,7 +175,7 @@ jobs:
 
       - name: Build Container Image
         id: build
-        uses: stackabletech/actions/build-container-image@bc17d3c4808a2343685853d0d757ad7614f660d4 # v0.17.4
+        uses: stackabletech/actions/build-container-image@0fe048f952bee522474903a925ea48dc706a0bb4 # v0.17.5
         with:
           image-name: ${{ env.OPERATOR_NAME }}
           image-index-manifest-tag: ${{ steps.version.outputs.OPERATOR_VERSION }}
@@ -184,7 +184,7 @@ jobs:
 
       - name: Publish Container Image to oci.stackable.tech
         if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: stackabletech/actions/publish-image@bc17d3c4808a2343685853d0d757ad7614f660d4 # v0.17.4
+        uses: stackabletech/actions/publish-image@0fe048f952bee522474903a925ea48dc706a0bb4 # v0.17.5
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -195,7 +195,7 @@ jobs:
 
       - name: Publish Container Image to quay.io
         if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: stackabletech/actions/publish-image@bc17d3c4808a2343685853d0d757ad7614f660d4 # v0.17.4
+        uses: stackabletech/actions/publish-image@0fe048f952bee522474903a925ea48dc706a0bb4 # v0.17.5
         with:
           image-registry-uri: quay.io
           image-registry-username: stackable+robot_sdp_github_action_build
@@ -225,7 +225,7 @@ jobs:
           persist-credentials: false
 
       - name: Publish and Sign Image Index to oci.stackable.tech
-        uses: stackabletech/actions/publish-image-index-manifest@bc17d3c4808a2343685853d0d757ad7614f660d4 # v0.17.4
+        uses: stackabletech/actions/publish-image-index-manifest@0fe048f952bee522474903a925ea48dc706a0bb4 # v0.17.5
         with:
           image-registry-uri: oci.stackable.tech
           image-registry-username: robot$sdp+github-action-build
@@ -234,7 +234,7 @@ jobs:
           image-index-manifest-tag: ${{ needs.build-container-image.outputs.operator-version }}
 
       - name: Publish and Sign Image Index to quay.io
-        uses: stackabletech/actions/publish-image-index-manifest@bc17d3c4808a2343685853d0d757ad7614f660d4 # v0.17.4
+        uses: stackabletech/actions/publish-image-index-manifest@0fe048f952bee522474903a925ea48dc706a0bb4 # v0.17.5
         with:
           image-registry-uri: quay.io
           image-registry-username: stackable+robot_sdp_github_action_build
@@ -264,7 +264,7 @@ jobs:
           submodules: recursive
 
       - name: Package, Publish, and Sign Helm Chart to oci.stackable.tech
-        uses: stackabletech/actions/publish-helm-chart@bc17d3c4808a2343685853d0d757ad7614f660d4 # v0.17.4
+        uses: stackabletech/actions/publish-helm-chart@0fe048f952bee522474903a925ea48dc706a0bb4 # v0.17.5
         with:
           chart-registry-uri: oci.stackable.tech
           chart-registry-username: robot$sdp-charts+github-action-build
@@ -276,7 +276,7 @@ jobs:
           publish-and-sign: ${{ !github.event.pull_request.head.repo.fork }}
 
       - name: Package, Publish, and Sign Helm Chart to quay.io
-        uses: stackabletech/actions/publish-helm-chart@bc17d3c4808a2343685853d0d757ad7614f660d4 # v0.17.4
+        uses: stackabletech/actions/publish-helm-chart@0fe048f952bee522474903a925ea48dc706a0bb4 # v0.17.5
         with:
           chart-registry-uri: quay.io
           chart-registry-username: stackable+robot_sdp_charts_github_action_build
@@ -308,13 +308,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run OpenShift Preflight Check for oci.stackable.tech
-        uses: stackabletech/actions/run-openshift-preflight@bc17d3c4808a2343685853d0d757ad7614f660d4 # v0.17.4
+        uses: stackabletech/actions/run-openshift-preflight@0fe048f952bee522474903a925ea48dc706a0bb4 # v0.17.5
         with:
           image-index-uri: oci.stackable.tech/sdp/${{ env.OPERATOR_NAME }}:${{ needs.build-container-image.outputs.operator-version }}
           image-architecture: ${{ matrix.arch }}
 
       - name: Run OpenShift Preflight Check for quay.io
-        uses: stackabletech/actions/run-openshift-preflight@bc17d3c4808a2343685853d0d757ad7614f660d4 # v0.17.4
+        uses: stackabletech/actions/run-openshift-preflight@0fe048f952bee522474903a925ea48dc706a0bb4 # v0.17.5
         with:
           image-index-uri: quay.io/stackable/sdp/${{ env.OPERATOR_NAME }}:${{ needs.build-container-image.outputs.operator-version }}
           image-architecture: ${{ matrix.arch }}
@@ -380,7 +380,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Notification
-        uses: stackabletech/actions/send-slack-notification@bc17d3c4808a2343685853d0d757ad7614f660d4 # v0.17.4
+        uses: stackabletech/actions/send-slack-notification@0fe048f952bee522474903a925ea48dc706a0bb4 # v0.17.5
         with:
           publish-helm-chart-result: ${{ needs.publish-helm-chart.result }}
           publish-manifests-result: ${{ needs.publish-index-manifest.result }}

--- a/template/.github/workflows/integration-test-custom.yaml
+++ b/template/.github/workflows/integration-test-custom.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run Integration Test
         id: test
-        uses: stackabletech/actions/run-integration-test@bc17d3c4808a2343685853d0d757ad7614f660d4 # v0.17.4
+        uses: stackabletech/actions/run-integration-test@0fe048f952bee522474903a925ea48dc706a0bb4 # v0.17.5
         with:
           replicated-api-token: ${{ secrets.REPLICATED_API_TOKEN }}
           otlp-bearer-token: ${{ secrets.OTLP_BEARER_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
 
       - name: Send Notification
         if: ${{ failure() || github.run_attempt > 1 }}
-        uses: stackabletech/actions/send-slack-notification@bc17d3c4808a2343685853d0d757ad7614f660d4 # v0.17.4
+        uses: stackabletech/actions/send-slack-notification@0fe048f952bee522474903a925ea48dc706a0bb4 # v0.17.5
         with:
           slack-token: ${{ secrets.SLACK_INTEGRATION_TEST_TOKEN }}
           failed-tests: ${{ steps.test.outputs.failed-tests }}

--- a/template/.github/workflows/integration-test-profile.yaml
+++ b/template/.github/workflows/integration-test-profile.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run Integration Test
         id: test
-        uses: stackabletech/actions/run-integration-test@bc17d3c4808a2343685853d0d757ad7614f660d4 # v0.17.4
+        uses: stackabletech/actions/run-integration-test@0fe048f952bee522474903a925ea48dc706a0bb4 # v0.17.5
         with:
           replicated-api-token: ${{ secrets.REPLICATED_API_TOKEN }}
           otlp-bearer-token: ${{ secrets.OTLP_BEARER_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
 
       - name: Send Notification
         if: ${{ failure() || github.run_attempt > 1 }}
-        uses: stackabletech/actions/send-slack-notification@bc17d3c4808a2343685853d0d757ad7614f660d4 # v0.17.4
+        uses: stackabletech/actions/send-slack-notification@0fe048f952bee522474903a925ea48dc706a0bb4 # v0.17.5
         with:
           slack-token: ${{ secrets.SLACK_INTEGRATION_TEST_TOKEN }}
           failed-tests: ${{ steps.test.outputs.failed-tests }}

--- a/template/.github/workflows/pr_prek.yaml.j2
+++ b/template/.github/workflows/pr_prek.yaml.j2
@@ -30,7 +30,7 @@ jobs:
           persist-credentials: false
           submodules: recursive
           fetch-depth: 0
-      - uses: stackabletech/actions/run-prek@bc17d3c4808a2343685853d0d757ad7614f660d4 # v0.17.4
+      - uses: stackabletech/actions/run-prek@0fe048f952bee522474903a925ea48dc706a0bb4 # v0.17.5
         with:
           rust: ${{ env.RUST_TOOLCHAIN_VERSION }}
           hadolint: ${{ env.HADOLINT_VERSION }}


### PR DESCRIPTION
This PR bump stackabletech/actions to v0.17.5 in local and templated workflows.