### PR TITLE
ci(template): Change operator version behaviour

### DIFF
--- a/template/.github/workflows/build.yaml.j2
+++ b/template/.github/workflows/build.yaml.j2
@@ -151,12 +151,18 @@ jobs:
 
           CURRENT_VERSION=$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "stackable-{[ operator.name }]") | .version')
 
+          # Include a PR suffix if this workflow is triggered by a PR
           if [ "$GITHUB_EVENT_NAME" == 'pull_request' ]; then
-            # Include a PR suffix if this workflow is triggered by a PR
-            if [ "$PR_BASE_REF" == 'main' ]; then
-              NEW_VERSION="0.0.0-pr$PR_NUMBER"
-            else
+            # If the PR is raised against a release branch, use the current operator version and
+            # append a suffix to it. If the PR is raised against ANY other base branch, use the
+            # established 0.0.0-prXXX tag.
+            if [[ "$PR_BASE_REF" =~ ^release-[0-9]{2}\.[0-9]{1,2}$ ]]; then
               NEW_VERSION="$CURRENT_VERSION-pr$PR_NUMBER"
+            else
+              # NOTE (@Techassi): One could argue that we should warn the developer when the current
+              # version is not 0.0.0-dev (and the PR potentially doesn't target main) that we will
+              # still rewrite the version to 0.0.0-prXXX.
+              NEW_VERSION="0.0.0-pr$PR_NUMBER"
             fi
           else
             # Just use the current version if this workflow is run on push, schedule, etc...


### PR DESCRIPTION
Previously, we only used 0.0.0-prXXX for the image tag if the PR targeted the main branch. This could lead to surprising results, because some PRs might be raised against a different feature branch (potentially part of a different PR). In these cases, the current version (most likely 0.0.0-dev) would be used and the -prXXX was appended to it, resulting in a surprising version tag 0.0.0-dev-prXXX.

To address this, we decided to only use the current version for PRs raised against release branches where this version scheme makes sense (that behaviour was also our intend when we initially wrote that script). For ANY other branch, we now always use 0.0.0-prXXX.

We could further improve the logic by checking if the current version differs from 0.0.0-dev and then use the version as is with a -prXXX suffix. If the version is 0.0.0-dev, we use the established 0.0.0-prXXX version.