### PR TITLE
fix: Port the serviceAccount.name/create fix into the template

### DIFF
--- a/template/deploy/helm/[[operator]]/templates/_helpers.tpl
+++ b/template/deploy/helm/[[operator]]/templates/_helpers.tpl
@@ -65,9 +65,9 @@ Create the name of the service account to use
 */}}
 {{- define "operator.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "operator.fullname" .) .Values.serviceAccount.name }}
+{{- default (printf "%s-serviceaccount" (include "operator.fullname" .)) .Values.serviceAccount.name }}
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- required "serviceAccount.name is required when serviceAccount.create is false, because the chart then does not create a ServiceAccount for the operator to run as." .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
 

--- a/template/deploy/helm/[[operator]]/templates/deployment.yaml.j2
+++ b/template/deploy/helm/[[operator]]/templates/deployment.yaml.j2
@@ -30,7 +30,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "operator.fullname" . }}-serviceaccount
+      serviceAccountName: {{ include "operator.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/template/deploy/helm/[[operator]]/templates/serviceaccount.yaml.j2
+++ b/template/deploy/helm/[[operator]]/templates/serviceaccount.yaml.j2
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "operator.fullname" . }}-serviceaccount
+  name: {{ include "operator.serviceAccountName" . }}
   labels:
     {{- include "operator.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
@@ -20,7 +20,7 @@ metadata:
     {{- include "operator.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "operator.fullname" . }}-serviceaccount
+    name: {{ include "operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
Ports stackabletech/hive-operator#742 into the template. 

- the Deployment and the ServiceAccount resolve their name through `operator.serviceAccountName` instead of hardcoding `<fullname>-serviceaccount`, which is what makes `.Values.serviceAccount.name` take effect at all
- with `create=false` the helper fell back to `"default"`, giving a pod running as the namespace default ServiceAccount without the operator ClusterRole. It now requires `serviceAccount.name`.

This should not be rolled out before stackabletech/listener-operator#418 and stackabletech/secret-operator#736 are merged.