### PR TITLE
fix: Always create the operator ClusterRoleBinding

### DIFF
--- a/template/deploy/helm/[[operator]]/templates/serviceaccount.yaml.j2
+++ b/template/deploy/helm/[[operator]]/templates/serviceaccount.yaml.j2
@@ -10,9 +10,11 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-# This cluster role binding allows anyone in the "manager" group to read secrets in any namespace.
+# Grants the operator ServiceAccount the ClusterRole from roles.yaml, which is what lets the
+# operator watch and manage its custom resources across the cluster.
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "operator.fullname" . }}-clusterrolebinding
@@ -26,4 +28,3 @@ roleRef:
   kind: ClusterRole
   name: {{ include "operator.fullname" . }}-clusterrole
   apiGroup: rbac.authorization.k8s.io
-{{- end }}


### PR DESCRIPTION
FYI: Reported by @dervoeti on stackabletech/listener-operator#418

I actually saw this in hive-operator but thought there was a good reason for it I was missing. Seems there is not.
This was added in 2022: https://github.com/stackabletech/operator-templating/pull/7 but it actually came earlier in https://github.com/stackabletech/zookeeper-operator/pull/247 and Claude tells me that this looks very much like kubebuilder templates. I have not verified that but would trust it. So it seems we bootstrapped parts of that from kubebuilder but back then actually three objects were behind the `if`: ServiceAccount, ClusterRoleBinding and ClusterRole. @soenkeliebau  then split the ClusterRole out and moving only that OUT of the `if`. I assume none of that was intentional.

@dervoeti suggested renaming all of this to `rbac.create` but then we should maybe move the ClusterRole back as well. I suggest we merge this as is though and we can always reconsider....

The one problem I have is that this _might_ want a changelog entry which we can't do using templating as far as I'm aware... but at least a release note should be added.