### PR TITLE
chore(template): Use .yaml extension for artifacthub-repo.yml

### DIFF
--- a/config/repositories.yaml
+++ b/config/repositories.yaml
@@ -47,7 +47,7 @@ repositories:
     # Druid is being deprecated and removed from SDP, so it has no
     # Artifact Hub repository and no metadata file.
     ignored_files:
-      - deploy/helm/artifacthub-repo.yml.j2
+      - deploy/helm/artifacthub-repo.yaml.j2
     chart_description: Kubernetes operator for Apache Druid. Deploy and run Druid clusters with the Stackable Data Platform (SDP).
     keywords:
       - apache-druid

--- a/config/retired_files.yaml
+++ b/config/retired_files.yaml
@@ -12,5 +12,6 @@ retired_files:
   - .github/ISSUE_TEMPLATE/new_version.md
   - .github/ISSUE_TEMPLATE/bug_report.yml
   - deploy/config-spec
+  - deploy/helm/artifacthub-repo.yml
   - deploy/helm/[[operator.name]]/configs
   - deploy/helm/[[operator.name]]/templates/configmap.yaml

--- a/template/deploy/helm/artifacthub-repo.yaml.j2
+++ b/template/deploy/helm/artifacthub-repo.yaml.j2
@@ -6,7 +6,7 @@
 #
 #   oras push oci.stackable.tech/sdp-charts/{[ operator.name }]:artifacthub.io \
 #     --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
-#     artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
+#     artifacthub-repo.yaml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
 #
 # Reference: https://github.com/artifacthub/hub/blob/master/docs/metadata/artifacthub-repo.yml and https://artifacthub.io/docs/topics/repositories/#verified-publisher
 
@@ -16,10 +16,10 @@
 # Every operator that gets this file has an ID. An operator without an Artifact Hub
 # repository excludes the file entirely via `ignored_files` in
 # config/repositories.yaml, the way druid does while it is being removed from SDP.
-repositoryID: {[ operator.artifacthub_repository_id }]
+repositoryID: "{[ operator.artifacthub_repository_id }]"
 
 # Versions Artifact Hub should not index.
 # This excludes all dev/rc/pr charts.
 ignore:
-  - name: {[ operator.name }]
-    version: '-(dev|rc|pr)'
+  - name: "{[ operator.name }]"
+    version: "-(dev|rc|pr)"


### PR DESCRIPTION
We generelly discourage using `.yml` for YAML files. Artifact Hub supports both according to their tests and code.

This rename also resulted in yamllint to pick up the file.